### PR TITLE
Jenkins plugin changes for Plastic SCM 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <artifactId>plasticscm-plugin</artifactId>
   <name>PlasticSCM Plugin</name>
-  <version>1.1-SNAPSHOT</version>
+  <version>2.0</version>
   <packaging>hpi</packaging>
   <description>Integrates Jenkins to Plastic SCM</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/PlasticSCM+Plugin</url>
@@ -22,9 +22,9 @@
 
   <developers>
       <developer>
-          <id>dickp</id>
-          <name>Dick Porter</name>
-          <email>dporter@codicesoftware.com</email>
+          <id>ravelus</id>
+          <name>Luis Rodriguez</name>
+          <email>lrodriguez@codicesoftware.com</email>
           <organization>Codice Software</organization>
           <organizationUrl>http://www.codicesoftware.com</organizationUrl>
       </developer>

--- a/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
@@ -38,15 +38,18 @@ public class CheckoutAction {
                 workspacePath.deleteContents();
             }
             workspace = workspaces.newWorkspace(workspacePath, workspaceName, ".", selector);
+            server.getFiles(".");
         } else {
             workspace = workspaces.getWorkspace(workspaceName);
             if (!workspace.getSelector().equals(selector)) {
                 workspace.setSelector(selector);
                 workspaces.setWorkspaceSelector(workspacePath, workspace);
             }
+            else {
+            	server.getFiles(".");
+            }
         }
 
-        server.getFiles(".");
 
         if (lastBuildTimestamp != null) {
             return server.getDetailedHistory(lastBuildTimestamp, currentBuildTimestamp);

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/GetWorkspaceInfoCommand.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/GetWorkspaceInfoCommand.java
@@ -13,6 +13,8 @@ public class GetWorkspaceInfoCommand extends AbstractCommand implements Parseabl
     private static final Pattern repoRegex = Pattern.compile("^Repository:\\s*(.+)$");
     private static final Pattern branchRegex = Pattern.compile("^Branch:\\s*(.+)$");
     private static final Pattern labelRegex = Pattern.compile("^Label:\\s*(.+)$");
+    private static final String DEFAULT_SEPARATOR = "def#_#sep";
+    private static final String ERROR_MSG_PREFIX = "ERROR";
 
     public GetWorkspaceInfoCommand(ServerConfigurationProvider provider) {
         super(provider);
@@ -22,34 +24,43 @@ public class GetWorkspaceInfoCommand extends AbstractCommand implements Parseabl
         MaskedArgumentListBuilder arguments = new MaskedArgumentListBuilder();
 
         arguments.add("wi");
+        arguments.add("--machinereadable");
+        arguments.add("--fieldseparator=" + DEFAULT_SEPARATOR);
 
         return arguments;
     }
 
     public WorkspaceInfo parse(Reader r) throws IOException, ParseException {
-        BufferedReader reader = new BufferedReader(r);
+        
+    	BufferedReader reader = new BufferedReader(r);
+        
         String line = reader.readLine();
-        String repoName = "";
-        String branch = "";
-        String label = "";
-        while (line != null) {
-            Matcher matcher = repoRegex.matcher(line);
-            if (matcher.find()) {
-                repoName = matcher.group(1);
-            } else {
-                matcher = branchRegex.matcher(line);
-                if (matcher.find()) {
-                    branch = matcher.group(1);
-                } else {
-                    matcher = labelRegex.matcher(line);
-                    if (matcher.find()) {
-                        label = matcher.group(1);
-                    }
-                }
-            }
-            line = reader.readLine();
+        String[] fields = null;
+        if (line != null) {
+        	
+        	fields = line.split(DEFAULT_SEPARATOR, -1);
+        }
+        
+        if (fields == null || fields.length == 0) {
+            return null;
         }
 
-        return new WorkspaceInfo(repoName, branch, label);
+        if (ERROR_MSG_PREFIX.equals(fields[0])) {
+            return null;
+        }
+
+        String branch = "";
+        String label = "";
+        
+        if (fields[0].equals("BR"))
+        {
+        	branch = fields[1];
+        }
+        else //suppose that fields[0].equals("LB")
+        {
+        	label = fields[1];
+        }        
+        
+        return new WorkspaceInfo(fields[2], branch, label);
     }
 }

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/SetSelectorCommand.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/SetSelectorCommand.java
@@ -19,7 +19,6 @@ public class SetSelectorCommand extends AbstractCommand {
 
         arguments.add("sts");
         arguments.add("--file=" + selectorFile.getName());
-        arguments.add("--noupdate");
         arguments.add("wk:" + workspaceName);
 
         return arguments;


### PR DESCRIPTION
I've changed the Jenkins plugin for Plastic SCM 4.0.

This version is necessary to work with Plastic SCM 4.0, and it's not compatible with Plastic SCM 3.0.

I would like it to be merged in the next Jenkins release.

Thanks,
Luis
