### PR TITLE
FilePath(File()) does not respect the OS of the remote machine.

### DIFF
--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/CommandRunner.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/CommandRunner.java
@@ -2,6 +2,8 @@ package com.codicesoftware.plugins.hudson.commands;
 
 import com.codicesoftware.plugins.hudson.PlasticTool;
 import hudson.FilePath;
+import hudson.model.Computer;
+import hudson.remoting.VirtualChannel;
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
@@ -17,7 +19,7 @@ public class CommandRunner {
     public static Reader execute(PlasticTool tool, Command cmd, String executionPath) throws IOException, InterruptedException {
         return tool.execute(
                 cmd.getArguments().toCommandArray(),
-                executionPath == null ? null : new FilePath(new File(executionPath)));
+                executionPath==null ? null : new FilePath(Computer.currentComputer().getChannel(),executionPath));
     }
 
     public static <T> T executeAndRead(PlasticTool tool, Command command, ParseableCommand<T> parser)


### PR DESCRIPTION
I'm using a jenkins master running on windows, with slave that are windows, linux and iOS.   2.13 was the last plugin that worked with my setup, because the / was always getting messed up on the unix machines. Here is the fix I came up with.

File() is always run on the local machine (master) so any paths run through it would be converted to the OS of the master node.  This was problematic when the remote and the master had different OS.   Using FilePath(File) also converted based upon the OS of the master.   This change uses FilePath(Channel, String) to use the channel to the remote server so that the path is correctly configured for the remote OS, irrespective of the master OS.