### PR TITLE
Only run cm update with branch selector

### DIFF
--- a/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
@@ -59,9 +59,10 @@ public class CheckoutAction {
 
             String uniqueWorkspaceName = WorkspaceManager.generateUniqueWorkspaceName();
             workspace = WorkspaceManager.newWorkspace(tool, workspacePath, uniqueWorkspaceName, selector);
+        } else {
+            WorkspaceManager.cleanWorkspace(tool, workspace.getPath());
         }
 
-        WorkspaceManager.cleanWorkspace(tool, workspace.getPath());
         WorkspaceManager.setWorkspaceSelector(tool, workspacePath, selector);
 
         return workspace;

--- a/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
@@ -67,10 +67,6 @@ public class CheckoutAction {
         return workspace;
     }
 
-    private static String removeNewLinesFromSelector(String selector) {
-        return selector.trim().replace("\r\n", "").replace("\n", "").replace("\r", "");
-    }
-
     private static void cleanOldWorkspacesIfNeeded(
             PlasticTool tool,
             FilePath workspacePath,

--- a/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
@@ -55,7 +55,7 @@ public class CheckoutAction {
                 return workspace;
             }
 
-            if (SelectorNeedsUpdate(selector)) {
+            if (!isChangesetOrLabelSelector(selector)) {
                 WorkspaceManager.updateWorkspace(tool, workspace.getPath());
             }
             return workspace;
@@ -83,8 +83,8 @@ public class CheckoutAction {
         return selector.trim().replace("\r\n", "").replace("\n", "").replace("\r", "");
     }
 
-    private static boolean SelectorNeedsUpdate(String selector) {
-        return !selector.contains("changeset") && !selector.contains("label");
+    private static boolean isChangesetOrLabelSelector(String selector) {
+        return selector.contains("changeset") || selector.contains("label");
     }
 
     private static void cleanOldWorkspacesIfNeeded(

--- a/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
@@ -2,22 +2,14 @@ package com.codicesoftware.plugins.hudson.actions;
 
 import com.codicesoftware.plugins.hudson.PlasticTool;
 import com.codicesoftware.plugins.hudson.WorkspaceManager;
-import com.codicesoftware.plugins.hudson.commands.CommandRunner;
-import com.codicesoftware.plugins.hudson.commands.GetSelectorSpecCommand;
 import com.codicesoftware.plugins.hudson.model.Workspace;
-import com.codicesoftware.plugins.hudson.model.WorkspaceInfo;
 import hudson.FilePath;
 import org.apache.commons.io.FilenameUtils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
@@ -52,6 +52,7 @@ public class CheckoutAction {
             String uniqueWorkspaceName = WorkspaceManager.generateUniqueWorkspaceName();
             workspace = WorkspaceManager.newWorkspace(tool, workspacePath, uniqueWorkspaceName, selector);
         } else {
+            LOGGER.fine("Using existing workspace: " + workspace.getName());
             WorkspaceManager.cleanWorkspace(tool, workspace.getPath());
         }
 

--- a/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/actions/CheckoutAction.java
@@ -54,7 +54,10 @@ public class CheckoutAction {
                 WorkspaceManager.setWorkspaceSelector(tool, workspacePath, selector);
                 return workspace;
             }
-            WorkspaceManager.updateWorkspace(tool, workspace.getPath());
+
+            if (SelectorNeedsUpdate(selector)) {
+                WorkspaceManager.updateWorkspace(tool, workspace.getPath());
+            }
             return workspace;
         }
 
@@ -78,6 +81,10 @@ public class CheckoutAction {
 
     private static String removeNewLinesFromSelector(String selector) {
         return selector.trim().replace("\r\n", "").replace("\n", "").replace("\r", "");
+    }
+
+    private static boolean SelectorNeedsUpdate(String selector) {
+        return !selector.contains("changeset") && !selector.contains("label");
     }
 
     private static void cleanOldWorkspacesIfNeeded(


### PR DESCRIPTION
As reported by @ahatala in PR #33 and issue #34, the checkout action updates workspaces even if they're switched to a changeset. In those scenarios, the Plastic SCM plugin shouldn't update to the latest changeset in the branch of the selector changeset.

That change of behavior came from the `update` command in Plastic SCM CLI.

This PR modifies the behavior of the checkout action to skip the update action if the current selector includes the word 'changeset' or 'label'. The update will still run if you change the selector, no matter what's in it.

Resolves #34 