### PR TITLE
Fix XML output in commands

### DIFF
--- a/src/main/java/com/codicesoftware/plugins/hudson/OutputTempFile.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/OutputTempFile.java
@@ -1,9 +1,8 @@
 package com.codicesoftware.plugins.hudson;
 
+import hudson.FilePath;
+
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -12,17 +11,16 @@ public class OutputTempFile {
 
     private OutputTempFile() { }
 
-    public static String getPathForXml() {
-        return Paths
-            .get(System.getProperty("java.io.tmpdir"))
-            .resolve(UUID.randomUUID().toString() + ".xml")
-            .toString();
+    public static FilePath getPathForXml(FilePath workspacePath) throws IOException, InterruptedException {
+        return workspacePath.createTempFile("output_", ".xml");
     }
 
-    public static void safeDelete(String path) {
+    public static void safeDelete(FilePath path) {
         try {
-            Files.deleteIfExists(Paths.get(path));
-        } catch (IOException e) {
+            if (path.exists()) {
+                path.delete();
+            }
+        } catch (Exception e) {
             LOGGER.log(
                 Level.SEVERE, String.format("Unable to remove file '%s'", path), e);
         }

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/ChangesetLogCommand.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/ChangesetLogCommand.java
@@ -3,6 +3,7 @@ package com.codicesoftware.plugins.hudson.commands;
 import com.codicesoftware.plugins.hudson.commands.parsers.LogOutputParser;
 import com.codicesoftware.plugins.hudson.model.ChangeSet;
 import com.codicesoftware.plugins.hudson.util.MaskedArgumentListBuilder;
+import hudson.FilePath;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -11,9 +12,9 @@ import java.util.List;
 
 public class ChangesetLogCommand implements ParseableCommand<ChangeSet>, Command {
     private final String csetSpec;
-    private final String xmlOutputPath;
+    private final FilePath xmlOutputPath;
 
-    public ChangesetLogCommand(String csetSpec, String xmlOutputPath) {
+    public ChangesetLogCommand(String csetSpec, FilePath xmlOutputPath) {
         this.csetSpec = csetSpec;
         this.xmlOutputPath = xmlOutputPath;
     }
@@ -23,7 +24,7 @@ public class ChangesetLogCommand implements ParseableCommand<ChangeSet>, Command
 
         arguments.add("log");
         arguments.add(csetSpec);
-        arguments.add("--xml=" + xmlOutputPath);
+        arguments.add("--xml=" + xmlOutputPath.getRemote());
         arguments.add("--encoding=utf-8");
 
         return arguments;

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/ChangesetRangeLogCommand.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/ChangesetRangeLogCommand.java
@@ -3,6 +3,7 @@ package com.codicesoftware.plugins.hudson.commands;
 import com.codicesoftware.plugins.hudson.commands.parsers.LogOutputParser;
 import com.codicesoftware.plugins.hudson.model.ChangeSet;
 import com.codicesoftware.plugins.hudson.util.MaskedArgumentListBuilder;
+import hudson.FilePath;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -12,9 +13,9 @@ import java.util.List;
 public class ChangesetRangeLogCommand implements ParseableCommand<List<ChangeSet>>, Command {
     private final String csetSpecFrom;
     private final String csetSpecTo;
-    private final String xmlOutputPath;
+    private final FilePath xmlOutputPath;
 
-    public ChangesetRangeLogCommand(String csetSpecFrom, String csetSpecTo, String xmlOutputPath) {
+    public ChangesetRangeLogCommand(String csetSpecFrom, String csetSpecTo, FilePath xmlOutputPath) {
         this.csetSpecFrom = csetSpecFrom;
         this.csetSpecTo = csetSpecTo;
         this.xmlOutputPath = xmlOutputPath;

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/ChangesetsRetriever.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/ChangesetsRetriever.java
@@ -20,11 +20,12 @@ public class ChangesetsRetriever {
 
     public static List<ChangeSet> getChangesets(
             PlasticTool tool,
+            FilePath workspacePath,
             String branchName,
             String repoSpec,
             Calendar fromTimestamp,
             Calendar toTimestamp) throws IOException, InterruptedException, ParseException {
-        String xmlOutputFile = OutputTempFile.getPathForXml();
+        FilePath xmlOutputFile = OutputTempFile.getPathForXml(workspacePath);
 
         DetailedHistoryCommand histCommand = new DetailedHistoryCommand(
                 fromTimestamp, toTimestamp, branchName, repoSpec, xmlOutputFile);
@@ -43,7 +44,7 @@ public class ChangesetsRetriever {
             String repoSpec,
             Calendar fromTimestamp,
             Calendar toTimestamp) throws IOException, InterruptedException, ParseException {
-        List<ChangeSet> list = getChangesets(tool, branchName, repoSpec, fromTimestamp, toTimestamp);
+        List<ChangeSet> list = getChangesets(tool, wkPath, branchName, repoSpec, fromTimestamp, toTimestamp);
 
         GetWorkspaceFromPathCommand gwpCommand = new GetWorkspaceFromPathCommand(wkPath.getRemote());
         Workspace workspace = CommandRunner.executeAndRead(tool, gwpCommand, gwpCommand);

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/DetailedHistoryCommand.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/DetailedHistoryCommand.java
@@ -4,6 +4,7 @@ import com.codicesoftware.plugins.hudson.commands.parsers.FindOutputParser;
 import com.codicesoftware.plugins.hudson.model.ChangeSet;
 import com.codicesoftware.plugins.hudson.util.DateUtil;
 import com.codicesoftware.plugins.hudson.util.MaskedArgumentListBuilder;
+import hudson.FilePath;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -17,7 +18,7 @@ public class DetailedHistoryCommand implements ParseableCommand<List<ChangeSet>>
     private final Calendar toTimestamp;
     private final String branch;
     private final String repository;
-    private final String xmlOutputPath;
+    private final FilePath xmlOutputPath;
 
     private final SimpleDateFormat dateFormatter =
             new SimpleDateFormat(DateUtil.DEFAULT_SORTABLE_FORMAT);
@@ -27,7 +28,7 @@ public class DetailedHistoryCommand implements ParseableCommand<List<ChangeSet>>
             Calendar toTimestamp,
             String branch,
             String repository,
-            String xmlOutputPath) {
+            FilePath xmlOutputPath) {
         this.fromTimestamp = fromTimestamp;
         this.toTimestamp = toTimestamp;
         this.branch = branch;
@@ -53,7 +54,7 @@ public class DetailedHistoryCommand implements ParseableCommand<List<ChangeSet>>
         arguments.add("'" + repository + "'");
 
         arguments.add("--xml");
-        arguments.add("--file=" + xmlOutputPath);
+        arguments.add("--file=" + xmlOutputPath.getRemote());
         arguments.add("--dateformat=" + DateUtil.DEFAULT_SORTABLE_FORMAT);
 
 

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/FindChangesetCommand.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/FindChangesetCommand.java
@@ -4,6 +4,7 @@ import com.codicesoftware.plugins.hudson.commands.parsers.FindOutputParser;
 import com.codicesoftware.plugins.hudson.model.ChangeSet;
 import com.codicesoftware.plugins.hudson.util.DateUtil;
 import com.codicesoftware.plugins.hudson.util.MaskedArgumentListBuilder;
+import hudson.FilePath;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -15,10 +16,10 @@ public class FindChangesetCommand implements ParseableCommand<ChangeSet>, Comman
     private final int csetId;
     private final String branch;
     private final String repository;
-    private final String xmlOutputPath;
+    private final FilePath xmlOutputPath;
 
     public FindChangesetCommand(
-        int csetId, String branch, String repository, String xmlOutputPath) {
+        int csetId, String branch, String repository, FilePath xmlOutputPath) {
         this.csetId = csetId;
         this.branch = branch;
         this.repository = repository;
@@ -39,7 +40,7 @@ public class FindChangesetCommand implements ParseableCommand<ChangeSet>, Comman
         arguments.add("'" + repository + "'");
 
         arguments.add("--xml");
-        arguments.add("--file=" + xmlOutputPath);
+        arguments.add("--file=" + xmlOutputPath.getRemote());
         arguments.add("--dateformat=" + DateUtil.ISO_DATE_TIME_OFFSET_CSHARP_FORMAT);
 
         return arguments;

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/FindOutputParser.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/FindOutputParser.java
@@ -21,7 +21,7 @@ public class FindOutputParser {
     // Utility classes shouldn't have default constructors
     private FindOutputParser() { }
 
-    public static List<ChangeSet> parseReader(FilePath path) throws IOException, ParseException, InterruptedException {
+    public static List<ChangeSet> parseReader(FilePath path) throws IOException, ParseException {
         List<ChangeSet> csetList = new ArrayList<>();
 
         if (!SafeFilePath.exists(path)) {

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/FindOutputParser.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/FindOutputParser.java
@@ -6,13 +6,11 @@ import hudson.util.Digester2;
 import org.apache.commons.digester.Digester;
 import org.xml.sax.SAXException;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class FindOutputParser {

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/FindOutputParser.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/FindOutputParser.java
@@ -1,15 +1,18 @@
 package com.codicesoftware.plugins.hudson.commands.parsers;
 
 import com.codicesoftware.plugins.hudson.model.ChangeSet;
+import hudson.FilePath;
 import hudson.util.Digester2;
 import org.apache.commons.digester.Digester;
 import org.xml.sax.SAXException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class FindOutputParser {
@@ -18,10 +21,10 @@ public class FindOutputParser {
     // Utility classes shouldn't have default constructors
     private FindOutputParser() { }
 
-    public static List<ChangeSet> parseReader(String path) throws IOException, ParseException {
+    public static List<ChangeSet> parseReader(FilePath path) throws IOException, ParseException, InterruptedException {
         List<ChangeSet> csetList = new ArrayList<>();
-        File xmlFile = new File(path);
-        if (!xmlFile.exists()) {
+
+        if (!path.exists()) {
             LOGGER.warning("Find command XML output file not found: " + path);
             return csetList;
         }
@@ -40,8 +43,10 @@ public class FindOutputParser {
         digester.addBeanPropertySetter("*/CHANGESET/GUID", "guid");
         digester.addSetNext("*/CHANGESET", "add");
 
-        try {
-            digester.parse(xmlFile);
+        try (InputStream stream = SafeFilePath.read(path)) {
+            if (stream != null) {
+                digester.parse(stream);
+            }
         } catch (SAXException e) {
             throw new ParseException("Parse error: " + e.getMessage(), 0);
         }

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/FindOutputParser.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/FindOutputParser.java
@@ -24,7 +24,7 @@ public class FindOutputParser {
     public static List<ChangeSet> parseReader(FilePath path) throws IOException, ParseException, InterruptedException {
         List<ChangeSet> csetList = new ArrayList<>();
 
-        if (!path.exists()) {
+        if (!SafeFilePath.exists(path)) {
             LOGGER.warning("Find command XML output file not found: " + path);
             return csetList;
         }

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/LogOutputParser.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/LogOutputParser.java
@@ -6,7 +6,6 @@ import hudson.util.Digester2;
 import org.apache.commons.digester.Digester;
 import org.xml.sax.SAXException;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/SafeFilePath.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/SafeFilePath.java
@@ -1,0 +1,50 @@
+package com.codicesoftware.plugins.hudson.commands.parsers;
+
+import hudson.FilePath;
+import hudson.model.Computer;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class SafeFilePath {
+    private static final Logger LOGGER = Logger.getLogger(SafeFilePath.class.getName());
+
+    private SafeFilePath() {
+    }
+
+    static boolean exists(@Nonnull final FilePath filePath) {
+        try {
+            return filePath.exists();
+        } catch (Exception e) {
+            LOGGER.log(
+                Level.SEVERE,
+                String.format("Unable to determine whether file '%s' exists", getPrintableFilePath(filePath)),
+                e);
+            return false;
+        }
+    }
+
+    @CheckForNull
+    static InputStream read(@Nonnull final FilePath filePath) {
+        try {
+            return filePath.read();
+        } catch (Exception e) {
+            LOGGER.log(
+                Level.SEVERE,
+                String.format("Unable to open file %s' for read", getPrintableFilePath(filePath)),
+                e);
+            return null;
+        }
+    }
+
+    @Nonnull
+    private static String getPrintableFilePath(@Nonnull final FilePath path) {
+        Computer computer = path.toComputer();
+        return String.format(
+            "'%s' in '%s'",
+            path.getRemote(), computer != null ? computer.getName() : "master");
+    }
+}


### PR DESCRIPTION
The improvements in PR #36 only worked for master-only setups. Agents were utterly broken.

The mistake was to use `java.nio.Paths` instead of `hudson.FilePath`. Jenkins plugins need to use the latter because that class manages files in remote agents (which is the case). 

This PR replaces the local-only file classes with Jenkins' FilePath.