### PR TITLE
Expand environment variables in selector

### DIFF
--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
@@ -239,10 +239,13 @@ public class PlasticSCM extends SCM {
             ? Collections.emptyList()
             : parameters.getParameters();
 
+        EnvVars environment = run.getEnvironment(listener);
+
         for (WorkspaceInfo workspaceInfo : getAllWorkspaces()) {
 
             FilePath plasticWorkspacePath = resolveWorkspacePath(workspace, workspaceInfo);
-            String resolvedSelector = SelectorParametersResolver.resolve(workspaceInfo.getSelector(), parameterValues);
+            String resolvedSelector = SelectorParametersResolver.resolve(
+                workspaceInfo.getSelector(), parameterValues, environment);
 
             PlasticTool tool = new PlasticTool(
                 CmTool.get(node, run.getEnvironment(listener), listener),
@@ -395,10 +398,12 @@ public class PlasticSCM extends SCM {
         List<ParameterValue> parameters = getDefaultParameterValues(project);
         Run<?, ?> lastBuild = project.getLastBuild();
 
+        EnvVars environment = lastBuild.getEnvironment(listener);
+
         for (WorkspaceInfo workspaceInfo : getAllWorkspaces()) {
             FilePath plasticWorkspacePath = resolveWorkspacePath(workspace, workspaceInfo);
             String resolvedSelector = SelectorParametersResolver.resolve(
-                    workspaceInfo.selector, parameters);
+                workspaceInfo.selector, parameters, environment);
 
             boolean hasChanges = hasChanges(
                 project,

--- a/src/main/java/com/codicesoftware/plugins/hudson/util/SelectorParametersResolver.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/util/SelectorParametersResolver.java
@@ -1,5 +1,6 @@
 package com.codicesoftware.plugins.hudson.util;
 
+import hudson.EnvVars;
 import hudson.Util;
 import hudson.model.ParameterValue;
 
@@ -11,7 +12,7 @@ public class SelectorParametersResolver {
 
     private SelectorParametersResolver() { }
 
-    public static String resolve(String text, List<ParameterValue> parameters) {
+    public static String resolve(String text, List<ParameterValue> parameters, EnvVars environment) {
         if (parameters == null) {
             return text;
         }
@@ -23,8 +24,8 @@ public class SelectorParametersResolver {
             }
         }
 
-        return Util.replaceMacro(
-                resolveLegacyFormat(text, parametersMap), parametersMap);
+        return environment.expand(Util.replaceMacro(
+            resolveLegacyFormat(text, parametersMap), parametersMap));
     }
 
     static String resolveLegacyFormat(String text, Map<String, String> parametersMap) {

--- a/src/test/java/com/codicesoftware/plugins/hudson/util/SelectorParametersResolverTest.java
+++ b/src/test/java/com/codicesoftware/plugins/hudson/util/SelectorParametersResolverTest.java
@@ -1,5 +1,6 @@
 package com.codicesoftware.plugins.hudson.util;
 
+import hudson.EnvVars;
 import hudson.model.BooleanParameterValue;
 import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
@@ -18,10 +19,36 @@ public class SelectorParametersResolverTest {
         parameters.add(new StringParameterValue("PARAM", "VALUE"));
         parameters.add(new BooleanParameterValue("BOOL", true));
 
-        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample $PARAM text", parameters));
-        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} text", parameters));
-        assertEquals("sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters));
-        assertEquals("sample true text", SelectorParametersResolver.resolve("sample $BOOL text", parameters));
+        EnvVars environment = new EnvVars();
+
+        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample $PARAM text", parameters, environment));
+        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} text", parameters, environment));
+        assertEquals("sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
+        assertEquals("sample true text", SelectorParametersResolver.resolve("sample $BOOL text", parameters, environment));
+    }
+
+    @Test
+    public void testEnvironmentExpansion() {
+        List<ParameterValue> parameters = new LinkedList<>();
+        EnvVars environment = new EnvVars("PARAM", "VALUE", "BOOL", "true");
+
+        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample $PARAM text", parameters, environment));
+        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} text", parameters, environment));
+        assertEquals("sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
+        assertEquals("sample true text", SelectorParametersResolver.resolve("sample $BOOL text", parameters, environment));
+    }
+
+    @Test
+    public void testEnvironmentAndParameterExpansion() {
+        List<ParameterValue> parameters = new LinkedList<>();
+        parameters.add(new BooleanParameterValue("BOOL", true));
+
+        EnvVars environment = new EnvVars("PARAM", "VALUE");
+
+        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample $PARAM text", parameters, environment));
+        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} text", parameters, environment));
+        assertEquals("sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
+        assertEquals("sample true text", SelectorParametersResolver.resolve("sample $BOOL text", parameters, environment));
     }
 
     @Test
@@ -30,9 +57,11 @@ public class SelectorParametersResolverTest {
         parameters.add(new StringParameterValue("PARAM", "VALUE"));
         parameters.add(new BooleanParameterValue("BOOL", true));
 
-        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample %PARAM% text", parameters));
-        assertEquals("sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters));
-        assertEquals("sample true text", SelectorParametersResolver.resolve("sample %BOOL% text", parameters));
+        EnvVars environment = new EnvVars();
+
+        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample %PARAM% text", parameters, environment));
+        assertEquals("sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
+        assertEquals("sample true text", SelectorParametersResolver.resolve("sample %BOOL% text", parameters, environment));
     }
 
     @Test
@@ -41,8 +70,10 @@ public class SelectorParametersResolverTest {
         parameters.add(new StringParameterValue("PARAM", "VALUE"));
         parameters.add(new BooleanParameterValue("BOOL", true));
 
-        assertEquals("sample VALUE VALUE text", SelectorParametersResolver.resolve("sample %PARAM% $PARAM text", parameters));
-        assertEquals("sample VALUE VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} %PARAM% text", parameters));
-        assertEquals("sample true true text", SelectorParametersResolver.resolve("sample $BOOL %BOOL% text", parameters));
+        EnvVars environment = new EnvVars();
+
+        assertEquals("sample VALUE VALUE text", SelectorParametersResolver.resolve("sample %PARAM% $PARAM text", parameters, environment));
+        assertEquals("sample VALUE VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} %PARAM% text", parameters, environment));
+        assertEquals("sample true true text", SelectorParametersResolver.resolve("sample $BOOL %BOOL% text", parameters, environment));
     }
 }


### PR DESCRIPTION
The configured selector needs to replace values from environment variables.

This is particularly necessary in Global Pipeline Libraries, because they need to specify the version in the selector.

Our plugin wasn't resolving any environment variable value in the selector. This PR will change that so selectors are aware of environment variables.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
