### PR TITLE
Address forthcoming maven-license-plugin changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.47</version>
+    <version>3.57</version>
     <relativePath />
   </parent>
 
@@ -63,11 +63,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.cloudbees</groupId>
-        <artifactId>maven-license-plugin</artifactId>
-        <version>1.8</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Forthcoming updates of the Jenkins plugin pom have incorporated breaking changes coming from the maven-license-plugin.
To warrant a smooth update downstream, the change proposes to drop the obsolete declaration of the maven-license-plugin. It's already declared and configured in the plugin pom.