### PR TITLE
Support shelves

### DIFF
--- a/doc/standalone-guide.md
+++ b/doc/standalone-guide.md
@@ -94,6 +94,14 @@ repository "myRepo@my.plasticscm.server.com:8087"
     label "1.0.32-preview_997"
 ```
 
+**Shelveset selector:**
+
+```text
+repository "myRepo@my.plasticscm.server.com:8087"
+  path "/"
+    shelve "51"
+```
+
 **Important!** Don't forget to use the `ssl://` prefix in the server name if your Plastic
 Server utilizes SSL. For instance, `repository "myRepo@ssl://my.plasticscm.server.com:8088"`
 
@@ -149,6 +157,8 @@ configuration, you can take advantage of the cm command inside the groovy script
 cm(
     branch: '<full-branch-name>',
     changeset: '<cset-number>', // optional
+    shelveset: '<shelveset-number>', // optional
+    label: '<label-name>', // optional
     repository: '<rep-name>',
     server: '<server-address>:<server-port>',
     cleanup: '<cleanup-strategy>',
@@ -161,7 +171,11 @@ cm(
 As you see, there's a one-to-one parameter mapping. To use multiple workspaces you simply need to
 add multiple `cm` statements, paying attention to the value of the `directory` parameter.
 
-You only need to specify the `changeset` parameter if you'd like all builds to target that changeset.
+You only need to specify the `changeset` parameter if you'd like all builds to target that changeset in the specified
+branch.
+
+Alternatively, you can specify the `shelveset` or the `label` parameter to target a shelveset or a label, respectively.
+In those instances, the `branch` parameter is ignored.
 
 The available values for `cleanup` are `MINIMAL`, `STANDARD`, `FULL` and `DELETE`.
 
@@ -185,7 +199,25 @@ cm(
     changeset: '538',
     repository: 'assets-repo',
     server: 'my.plasticscm.server.com:8087',
+    cleanup: 'STANDARD'
+)
+
+cm(
+    shelveset: '538',
+    repository: 'assets-repo',
+    server: 'my.other.plasticscm.server.com:8087',
     cleanup: 'STANDARD',
+    workingMode: 'LDAP',
+    credentialsId: 'my-ldap-credentials'
+)
+
+cm(
+    label: '1.0.1',
+    repository: 'assets-repo',
+    server: 'my.plasticscm.server.com:8087',
+    cleanup: 'STANDARD',
+    workingMode: 'UP',
+    credentialsId: 'my-credentials'
 )
 ```
 

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
@@ -27,6 +27,7 @@ public class PlasticSCMStep extends SCMStep {
     private static final Logger LOGGER = Logger.getLogger(PlasticSCMStep.class.getName());
 
     private String branch = DescriptorImpl.defaultBranch;
+    private String shelve = "";
     private String changeset = "";
     private String repository = "";
     private String server = "";
@@ -41,6 +42,15 @@ public class PlasticSCMStep extends SCMStep {
 
     @DataBoundConstructor
     public PlasticSCMStep() {
+    }
+
+    public String getShelve() {
+        return shelve;
+    }
+
+    @DataBoundSetter
+    public void setShelve(String shelve) {
+        this.shelve = shelve;
     }
 
     public String getBranch() {
@@ -129,10 +139,12 @@ public class PlasticSCMStep extends SCMStep {
     }
 
     private String buildSelector() {
-        if (Util.fixEmptyAndTrim(changeset) == null) {
-            return String.format(SelectorTemplates.BRANCH, repository, server, branch);
-        } else {
+        if (Util.fixEmptyAndTrim(changeset) != null) {
             return String.format(SelectorTemplates.CHANGESET, repository, server, branch, changeset);
+        } else if (Util.fixEmptyAndTrim(shelve) != null) {
+            return String.format(SelectorTemplates.SHELVE, repository, server, shelve);
+        } else {
+            return String.format(SelectorTemplates.BRANCH, repository, server, branch);
         }
     }
 

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
@@ -27,6 +27,7 @@ public class PlasticSCMStep extends SCMStep {
     private static final Logger LOGGER = Logger.getLogger(PlasticSCMStep.class.getName());
 
     private String branch = DescriptorImpl.defaultBranch;
+    private String label = "";
     private String shelve = "";
     private String changeset = "";
     private String repository = "";
@@ -51,6 +52,15 @@ public class PlasticSCMStep extends SCMStep {
     @DataBoundSetter
     public void setShelve(String shelve) {
         this.shelve = shelve;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = label;
     }
 
     public String getBranch() {
@@ -143,6 +153,8 @@ public class PlasticSCMStep extends SCMStep {
             return String.format(SelectorTemplates.CHANGESET, repository, server, branch, changeset);
         } else if (Util.fixEmptyAndTrim(shelve) != null) {
             return String.format(SelectorTemplates.SHELVE, repository, server, shelve);
+        } else if (Util.fixEmptyAndTrim(label) != null) {
+            return String.format(SelectorTemplates.LABEL, repository, server, label);
         } else {
             return String.format(SelectorTemplates.BRANCH, repository, server, branch);
         }

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
@@ -28,7 +28,7 @@ public class PlasticSCMStep extends SCMStep {
 
     private String branch = DescriptorImpl.defaultBranch;
     private String label = "";
-    private String shelve = "";
+    private String shelveset = "";
     private String changeset = "";
     private String repository = "";
     private String server = "";
@@ -45,13 +45,13 @@ public class PlasticSCMStep extends SCMStep {
     public PlasticSCMStep() {
     }
 
-    public String getShelve() {
-        return shelve;
+    public String getShelveset() {
+        return shelveset;
     }
 
     @DataBoundSetter
-    public void setShelve(String shelve) {
-        this.shelve = shelve;
+    public void setShelveset(String shelveset) {
+        this.shelveset = shelveset;
     }
 
     public String getLabel() {
@@ -151,8 +151,8 @@ public class PlasticSCMStep extends SCMStep {
     private String buildSelector() {
         if (Util.fixEmptyAndTrim(changeset) != null) {
             return String.format(SelectorTemplates.CHANGESET, repository, server, branch, changeset);
-        } else if (Util.fixEmptyAndTrim(shelve) != null) {
-            return String.format(SelectorTemplates.SHELVE, repository, server, shelve);
+        } else if (Util.fixEmptyAndTrim(shelveset) != null) {
+            return String.format(SelectorTemplates.SHELVESET, repository, server, shelveset);
         } else if (Util.fixEmptyAndTrim(label) != null) {
             return String.format(SelectorTemplates.LABEL, repository, server, label);
         } else {

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
@@ -149,12 +149,12 @@ public class PlasticSCMStep extends SCMStep {
     }
 
     private String buildSelector() {
-        if (Util.fixEmptyAndTrim(changeset) != null) {
-            return String.format(SelectorTemplates.CHANGESET, repository, server, branch, changeset);
-        } else if (Util.fixEmptyAndTrim(shelveset) != null) {
+        if (Util.fixEmptyAndTrim(shelveset) != null) {
             return String.format(SelectorTemplates.SHELVESET, repository, server, shelveset);
         } else if (Util.fixEmptyAndTrim(label) != null) {
             return String.format(SelectorTemplates.LABEL, repository, server, label);
+        } else if (Util.fixEmptyAndTrim(changeset) != null) {
+            return String.format(SelectorTemplates.CHANGESET, repository, server, branch, changeset);
         } else {
             return String.format(SelectorTemplates.BRANCH, repository, server, branch);
         }

--- a/src/main/java/com/codicesoftware/plugins/hudson/util/FormChecker.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/util/FormChecker.java
@@ -32,8 +32,8 @@ public class FormChecker {
         "^(\\s*(rep|repository)\\s+\"(.*)\"(\\s+mount\\s+\"(.*)\")?(\\s+path\\s+"
         + "\"(.*)\"(\\s+norecursive)?(\\s+((((((branch|br)\\s+\"(.*)\")(\\s+(revno\\s+"
         + "(\"\\d+\"|LAST|FIRST)|changeset\\s+\"\\S+\"))?(\\s+(label|lb)\\s+\"(.*)\")?)|"
-        + "(label|lb)\\s+\"(.*)\")(\\s+(checkout|co)\\s+\"(.*\"))?)|(branchpertask\\s+"
-        + "\"(.*)\"(\\s+baseline\\s+\"(.*)\")?)|(smartbranch\\s+\"(.*)\"))))+\\s*)+$",
+        + "(label|lb)\\s+\"(.*)\")(\\s+(checkout|co)\\s+\"(.*)\")?)|shelve\\s+\"(.*)\"|"
+        + "(branchpertask\\s+\"(.*)\"(\\s+baseline\\s+\"(.*)\")?)|(smartbranch\\s+\"(.*)\"))))+\\s*)+$",
         Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
     private static final Pattern NO_AT_CHAR_REGEX = Pattern.compile("^[^@]+$");
     private static final Pattern SERVER_REGEX = Pattern.compile("^.+:[0-9]+$");

--- a/src/main/java/com/codicesoftware/plugins/jenkins/SelectorTemplates.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/SelectorTemplates.java
@@ -9,6 +9,6 @@ public class SelectorTemplates {
     public static final String BRANCH = "repository \"%s@%s\"%n  path \"/\"%n    smartbranch \"%s\"";
     public static final String CHANGESET =
             "repository \"%s@%s\"%n  path \"/\"%n    smartbranch \"%s\" changeset \"%s\"";
-    public static final String SHELVE = "repository \"%s@%s\"%n  path \"/\"%n    shelve \"%s\"";
+    public static final String SHELVESET = "repository \"%s@%s\"%n  path \"/\"%n    shelve \"%s\"";
     public static final String LABEL = "repository \"%s@%s\"%n  path \"/\"%n    label \"%s\"";
 }

--- a/src/main/java/com/codicesoftware/plugins/jenkins/SelectorTemplates.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/SelectorTemplates.java
@@ -9,4 +9,5 @@ public class SelectorTemplates {
     public static final String BRANCH = "repository \"%s@%s\"%n  path \"/\"%n    smartbranch \"%s\"";
     public static final String CHANGESET =
             "repository \"%s@%s\"%n  path \"/\"%n    smartbranch \"%s\" changeset \"%s\"";
+    public static final String SHELVE = "repository \"%s@%s\"%n  path \"/\"%n    shelve \"%s\"";
 }

--- a/src/main/java/com/codicesoftware/plugins/jenkins/SelectorTemplates.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/SelectorTemplates.java
@@ -10,4 +10,5 @@ public class SelectorTemplates {
     public static final String CHANGESET =
             "repository \"%s@%s\"%n  path \"/\"%n    smartbranch \"%s\" changeset \"%s\"";
     public static final String SHELVE = "repository \"%s@%s\"%n  path \"/\"%n    shelve \"%s\"";
+    public static final String LABEL = "repository \"%s@%s\"%n  path \"/\"%n    label \"%s\"";
 }

--- a/src/main/resources/com/codicesoftware/plugins/hudson/PlasticSCMStep/config.jelly
+++ b/src/main/resources/com/codicesoftware/plugins/hudson/PlasticSCMStep/config.jelly
@@ -9,6 +9,14 @@
     <f:number default=""/>
   </f:entry>
 
+  <f:entry field="shelveset" title="${%Shelveset}" help="/plugin/plasticscm-plugin/shelveset.html">
+    <f:number default=""/>
+  </f:entry>
+
+  <f:entry field="label" title="${%Label}" help="/plugin/plasticscm-plugin/label.html">
+    <f:number default=""/>
+  </f:entry>
+
   <f:entry field="repository" title="${%Repository}" help="/plugin/plasticscm-plugin/repository.html">
     <f:textbox default="${descriptor.defaultRepository}" checkMethod="post" />
   </f:entry>

--- a/src/main/resources/com/codicesoftware/plugins/hudson/PlasticSCMStep/config.jelly
+++ b/src/main/resources/com/codicesoftware/plugins/hudson/PlasticSCMStep/config.jelly
@@ -14,7 +14,7 @@
   </f:entry>
 
   <f:entry field="label" title="${%Label}" help="/plugin/plasticscm-plugin/label.html">
-    <f:number default=""/>
+    <f:textbox default=""/>
   </f:entry>
 
   <f:entry field="repository" title="${%Repository}" help="/plugin/plasticscm-plugin/repository.html">

--- a/src/main/webapp/branch.html
+++ b/src/main/webapp/branch.html
@@ -3,4 +3,8 @@
     Name of the branch.<br/>
     Example: <code>/main/feature123</code>.
   </p>
+  <p>
+    If defined, the job will build the contents of the last changeset in this branch. Specifying a changeset,
+    label or shelveset will override this value.
+  </p>
 </div>

--- a/src/main/webapp/changeset.html
+++ b/src/main/webapp/changeset.html
@@ -1,5 +1,5 @@
 <div>
   <p>
-    If defined, the job will build the contents in use the specified changeset.
+    If defined, the job will build the contents in this changeset.
   </p>
 </div>

--- a/src/main/webapp/changeset.html
+++ b/src/main/webapp/changeset.html
@@ -1,5 +1,5 @@
 <div>
   <p>
-    If defined use this specific changeset instead of the latest one in the branch.
+    If defined, the job will build the contents in use the specified changeset.
   </p>
 </div>

--- a/src/main/webapp/changeset.html
+++ b/src/main/webapp/changeset.html
@@ -1,5 +1,5 @@
 <div>
   <p>
-    If defined, the job will build the contents in this changeset.
+    If defined along with a branch name, the job will build the contents in this changeset instead of the branch head.
   </p>
 </div>

--- a/src/main/webapp/label.html
+++ b/src/main/webapp/label.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    If defined, the job will build the contents in this label. Specifying a changeset or shelveset will override this
+    value.
+  </p>
+</div>

--- a/src/main/webapp/shelveset.html
+++ b/src/main/webapp/shelveset.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    If defined, the job will build the contents of the specified shelveset, unless you specified a changeset as well.
+  </p>
+</div>

--- a/src/main/webapp/shelveset.html
+++ b/src/main/webapp/shelveset.html
@@ -1,5 +1,6 @@
 <div>
   <p>
-    If defined, the job will build the contents of the specified shelveset, unless you specified a changeset as well.
+    If defined, the job will build the contents of the specified shelveset. Specifying a changeset will override this
+    value.
   </p>
 </div>


### PR DESCRIPTION
Allow users to enter 'shelveset' selectors for their Plastic SCM configurations in Jenkins, either for freestyle projects or pipelines from SCM. Addtionally, add two new parameters to the scripted pipeline command `cm`: `shelveset` to build from shelvesets, and `label` to build from labels.

### Testing done

These changes were manually tested. Only GUI behavior was involved.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
