### PR TITLE
Use the appropriate workspace path when specifying subdirs

### DIFF
--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
@@ -281,9 +281,9 @@ public class PlasticSCM extends SCM {
 
             ChangeSet cset = ChangesetDetails.forWorkspace(tool, plasticWorkspacePath, listener);
 
-            ChangeSet previousCset = retrieveLastBuiltChangeset(tool, run,  workspace, cset);
+            ChangeSet previousCset = retrieveLastBuiltChangeset(tool, run,  plasticWorkspacePath, cset);
             changeLogItems.addAll(retrieveMultipleChangesetDetails(
-                tool, workspace, listener, previousCset, cset));
+                tool, plasticWorkspacePath, listener, previousCset, cset));
 
             BuildData buildData = new BuildData(plasticWorkspace, cset);
             List<BuildData> actions = run.getActions(BuildData.class);

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
@@ -263,6 +263,10 @@ public class PlasticSCM extends SCM {
             String resolvedSelector = SelectorParametersResolver.resolve(
                 workspaceInfo.getSelector(), parameterValues, environment);
 
+            if (!plasticWorkspacePath.exists()) {
+                plasticWorkspacePath.mkdirs();
+            }
+
             PlasticTool tool = new PlasticTool(
                 CmTool.get(node, run.getEnvironment(listener), listener),
                 launcher,
@@ -275,7 +279,7 @@ public class PlasticSCM extends SCM {
 
             WorkspaceManager.setSelector(tool, plasticWorkspace.getPath(), resolvedSelector);
 
-            ChangeSet cset = ChangesetDetails.forWorkspace(tool, workspace, listener);
+            ChangeSet cset = ChangesetDetails.forWorkspace(tool, plasticWorkspacePath, listener);
 
             ChangeSet previousCset = retrieveLastBuiltChangeset(tool, run,  workspace, cset);
             changeLogItems.addAll(retrieveMultipleChangesetDetails(


### PR DESCRIPTION
Reported in #66 , the plugin is always targeting the Jenkins workspace path for its operations instead of the actual Plastic SCM path after applying the specified subdirectory names.

Resolves #66

### Testing done

Manual changes using a clean install of Jenkins.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
