### PR TITLE
Fix for polling not working properly when jenkins and plastic servers are in different time zones

### DIFF
--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/DetailedHistoryCommand.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/DetailedHistoryCommand.java
@@ -56,7 +56,7 @@ public class DetailedHistoryCommand implements ParseableCommand<List<ChangeSet>>
 
         arguments.add("--xml");
         arguments.add("--file=" + xmlOutputPath.getRemote());
-        arguments.add("--dateformat=" + DateUtil.DEFAULT_SORTABLE_FORMAT);
+        arguments.add("--dateformat=" + DateUtil.ISO_DATE_TIME_OFFSET_CSHARP_FORMAT);
 
 
         return arguments;

--- a/src/main/java/com/codicesoftware/plugins/hudson/util/DateUtil.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/util/DateUtil.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 public class DateUtil {
 
-    public static final String DEFAULT_SORTABLE_FORMAT = "yyyy'-'MM'-'dd'T'HH':'mm':'ss";
+    public static final String DEFAULT_SORTABLE_FORMAT = "yyyy'-'MM'-'dd'T'HH':'mm':'ssZZZ";
 
     public static final String ISO_DATE_TIME_OFFSET_CSHARP_FORMAT = "yyyy'-'MM'-'dd'T'HH':'mm':'sszzz";
 


### PR DESCRIPTION
Time zone information is not added to the timestamp when running the `cm find changesets` command making the plastic server think it is local to it. If the Jenkins and plastic servers are set to different time zones build triggers might be delayed or missed. This PR addresses this by adding time zone info to the timestamp.

### Testing done

This was tested by running a Jenkins server set to UTC and a plastic server set to UTC+2. A Jenkins job was created with a plastic checkout step and pollSCM trigger. A check-in was then done on the plastic server.

Before the fix it would take two hours before the change was picked up by the Jenkins server. After the fix it picked it up the next polling event.

Snippet from the Jenkins polling log:
```
[REDACTED] $ cm find changeset where date between '2023-08-14T14:25:01+0000' and '2023-08-15T08:19:10+0000' and branch='REDACTED' on repositories 'REDACTED' --xml --file=C:\REDACTED\output_10770472108764842262.xml --dateformat=yyyy'-'MM'-'dd'T'HH':'mm':'sszzz --server=REDACTED
Done. Took 1 sec
Changes found

```

No automated test was added since I'm unsure of how this could be achieved without an actual plastic server.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
