### PR TITLE
Update to Java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version X.X (05 Sept 2023)
+## Version X.X (pending)
 * The plugin now requires Java 11, and Jenkins 2.176.4 or higher.
 
 ## Version 4.4 (07 Aug 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release notes
 
+## Version 4.5 (05 Sept 2023)
+* Now works with Java 11 and Jenkins 2.176.4 or higher.
+
 ## Version 4.4 (07 Aug 2023)
 
 * Fixed checkout errors when using subdirectories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release notes
 
-## Version 4.5 (05 Sept 2023)
-* Now works with Java 11 and Jenkins 2.176.4 or higher.
+## Version X.X (05 Sept 2023)
+* The plugin now requires Java 11, and Jenkins 2.176.4 or higher.
 
 ## Version 4.4 (07 Aug 2023)
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You'll find a link in the build page sidebar to display the Plastic SCM data for
 
 # Requirements
 
-* Jenkins `2.60.3` or newer
+* Jenkins `2.176.4 (2019-09-25)` or newer
 * Plastic SCM command line client `10.0.16.6112` or newer
 
 # Upgrades
@@ -128,7 +128,7 @@ download all workspaces in the same directory!
 To build the plugin you will need:
 
 * [Maven](https://maven.apache.org/) version `3.5` or newer
-* [Java Development Kit (JDK)](https://jdk.java.net/) version `8`
+* [Java Development Kit (JDK)](https://jdk.java.net/) version `11`
 
 Run the following command to build the plugin:
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You'll find a link in the build page sidebar to display the Plastic SCM data for
 
 # Requirements
 
-* Jenkins `2.176.4 (2019-09-25)` or newer
+* Jenkins `2.176.4` (2019-09-25) or newer
 * Plastic SCM command line client `10.0.16.6112` or newer
 
 # Upgrades

--- a/pom.xml
+++ b/pom.xml
@@ -155,5 +155,10 @@
       <artifactId>commons-digester3</artifactId>
       <version>3.2</version>
     </dependency>
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.9.4</version>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.176.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -104,9 +104,6 @@
       <organizationUrl>https://www.plasticscm.com</organizationUrl>
     </developer>
     <developer>
-      <id>jessica-gutierrez</id>
-      <name>Jessica Gutierrez</name>
-      <email>jessica.gutierrez@unity3d.com</email>
       <organization>Unity Technologies</organization>
       <organizationUrl>https://www.plasticscm.com</organizationUrl>
     </developer>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,9 @@
       <organizationUrl>https://www.plasticscm.com</organizationUrl>
     </developer>
     <developer>
+      <id>danipen00</id>
+      <name>Daniel Peñalba</name>
+      <email>daniel.penalba@unity3d.com</email>
       <organization>Unity Technologies</organization>
       <organizationUrl>https://www.plasticscm.com</organizationUrl>
     </developer>

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
@@ -59,7 +59,7 @@ public class CmToolInstaller extends DownloadFromUrlInstaller {
         // Skip system tool check if it was previously installed
         // Admins can always disable the automatic installer to fall back to the path they specified for the tool
         if (!ignoreSystemTool && !installablePath.child(".installedFrom").exists()) {
-            FilePath existingHome = new FilePath(node.getChannel(), Util.fixEmpty(tool.getHome()));
+            FilePath existingHome = new FilePath(node.getChannel(), Objects.toString(tool.getHome(), ""));
             FilePath systemToolExistsPath = installablePath.child(".systemtool");
 
             if (systemToolExistsPath.exists()) {

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
@@ -16,7 +16,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+import hudson.Util;
 
 public class CmToolInstaller extends DownloadFromUrlInstaller {
     private static final String ID = "LATEST";

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
@@ -59,7 +59,7 @@ public class CmToolInstaller extends DownloadFromUrlInstaller {
         // Skip system tool check if it was previously installed
         // Admins can always disable the automatic installer to fall back to the path they specified for the tool
         if (!ignoreSystemTool && !installablePath.child(".installedFrom").exists()) {
-            FilePath existingHome = new FilePath(node.getChannel(), Objects.toString(tool.getHome(), ""));
+            FilePath existingHome = new FilePath(node.getChannel(), Util.fixEmpty(tool.getHome()));
             FilePath systemToolExistsPath = installablePath.child(".systemtool");
 
             if (systemToolExistsPath.exists()) {

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
@@ -3,6 +3,7 @@ package com.codicesoftware.plugins.jenkins.tools;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.tools.DownloadFromUrlInstaller;
@@ -16,7 +17,6 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 public class CmToolInstaller extends DownloadFromUrlInstaller {
     private static final String ID = "LATEST";
@@ -59,7 +59,7 @@ public class CmToolInstaller extends DownloadFromUrlInstaller {
         // Skip system tool check if it was previously installed
         // Admins can always disable the automatic installer to fall back to the path they specified for the tool
         if (!ignoreSystemTool && !installablePath.child(".installedFrom").exists()) {
-            FilePath existingHome = new FilePath(node.getChannel(), Objects.toString(tool.getHome(), ""));
+            FilePath existingHome = new FilePath(node.getChannel(), Util.fixNull(tool.getHome()));
             FilePath systemToolExistsPath = installablePath.child(".systemtool");
 
             if (systemToolExistsPath.exists()) {

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
@@ -16,7 +16,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import hudson.Util;
+import java.util.Objects;
 
 public class CmToolInstaller extends DownloadFromUrlInstaller {
     private static final String ID = "LATEST";

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
@@ -16,6 +16,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class CmToolInstaller extends DownloadFromUrlInstaller {
     private static final String ID = "LATEST";
@@ -58,7 +59,7 @@ public class CmToolInstaller extends DownloadFromUrlInstaller {
         // Skip system tool check if it was previously installed
         // Admins can always disable the automatic installer to fall back to the path they specified for the tool
         if (!ignoreSystemTool && !installablePath.child(".installedFrom").exists()) {
-            FilePath existingHome = new FilePath(node.getChannel(), tool.getHome());
+            FilePath existingHome = new FilePath(node.getChannel(), Objects.toString(tool.getHome(), ""));
             FilePath systemToolExistsPath = installablePath.child(".systemtool");
 
             if (systemToolExistsPath.exists()) {


### PR DESCRIPTION
This PR enables Java 11 support for the Jenkins plugin.

- Updated the `<jenkins.version>` to `2.176.4` (it's the minimum version that accepts Java 11.
- Fixed build and spotbugs.
- Updated [README.md](https://github.com/jenkinsci/plasticscm-plugin/blob/master/README.md) and [CHANGELOG.md](https://github.com/jenkinsci/plasticscm-plugin/blob/master/CHANGELOG.md) accordingly.

### Testing done
Published a build of the plugin (hpi) and test a manual install. See screenshot.
![image](https://github.com/jenkinsci/plasticscm-plugin/assets/501613/ae9a7e67-9c5b-4464-a081-1f1800b16ef7)

