### PR TITLE
Require Jenkins 2.440.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,11 @@
-#!/usr/bin/env groovy
-
-// Continuous integration builds are done by https://ci.jenkins.io/
-// Using step definitions from https://github.com/jenkins-infra/pipeline-library
-buildPlugin(platforms: ['linux'], jdkVersions: [8])
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  forkCount: '1C', // Run parallel tests on ci.jenkins.io for lower costs, faster feedback
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [ platform: 'linux', jdk: 21 ],
+    [ platform: 'windows', jdk: 17 ]
+])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.86</version>
     <relativePath />
   </parent>
 
@@ -30,26 +30,22 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.176.4</jenkins.version>
-    <java.level>8</java.level>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.440</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
   </properties>
 
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.4.0</version>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>9.0.1</version>
+            <version>10.17.0</version>
           </dependency>
         </dependencies>
         <configuration>
@@ -137,21 +133,30 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3208.vb_21177d4b_cd9</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>2.9</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.19</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
@@ -91,6 +91,7 @@ public class CmTool extends ToolInstallation implements NodeSpecific<CmTool>, En
         return home;
     }
 
+    @SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION", justification = "Paranoia check")
     private static CmTool[] getInstallations(DescriptorImpl descriptor) {
         CmTool[] installations;
         try {


### PR DESCRIPTION
### Require Jenkins 2.440.3 or newer

55% of the installations of the most recent release (4.4) are running 2.440.3 or newer as noted by [plugin installation statistics](https://stats.jenkins.io/pluginversions/plasticscm-plugin.html)

Jenkins  2.440.3 includes a fix for a critical security vulnerability. Users should upgrade to 2.440.3 or newer in order to have that critical fix.

### Testing done
Verified changes using `mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
