### PR TITLE
Dismiss unsafe class alerts about org.apache.commons.digester3.Digester 

### DIFF
--- a/src/main/java/com/codicesoftware/plugins/DigesterUtils.java
+++ b/src/main/java/com/codicesoftware/plugins/DigesterUtils.java
@@ -11,6 +11,9 @@ public class DigesterUtils {
         // private as it is an utility class
     }
 
+    // This method disables features that are known to allow XML External Entity (XXE) attacks
+    // unless forced to be insecure
+    @SuppressWarnings("lgtm[jenkins/unsafe-classes]")
     public static Digester createDigester(boolean secure) throws SAXException {
         Digester digester = new Digester();
         if (secure) {

--- a/src/main/java/com/codicesoftware/plugins/hudson/ChangeSetReader.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/ChangeSetReader.java
@@ -24,6 +24,8 @@ import java.util.List;
  */
 public class ChangeSetReader extends ChangeLogParser {
 
+    // DigesterUtils will return a secured Digester unless there's a UNSAFE property in ChangeSetReader set to "true"
+    @SuppressWarnings("lgtm[jenkins/unsafe-classes]")
     @Override
     public ChangeSetList parse(
             Run run, RepositoryBrowser<?> browser, File changelogFile)
@@ -36,6 +38,8 @@ public class ChangeSetReader extends ChangeLogParser {
         }
     }
 
+    // DigesterUtils will return a secured Digester unless there's a UNSAFE property in ChangeSetReader set to "true"
+    @SuppressWarnings("lgtm[jenkins/unsafe-classes]")
     public ChangeSetList parse(
             Run<?, ?> run, RepositoryBrowser<?> browser, Reader reader)
             throws IOException, SAXException {

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/FindOutputParser.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/FindOutputParser.java
@@ -21,6 +21,8 @@ public class FindOutputParser {
     // Utility classes shouldn't have default constructors
     private FindOutputParser() { }
 
+    // DigesterUtils will return a secured Digester unless there's a UNSAFE property in FindOutputParser set to "true"
+    @SuppressWarnings("lgtm[jenkins/unsafe-classes]")
     @Nonnull
     public static List<ChangeSet> parseReader(
             @Nonnull final ObjectSpecType specType,

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/LogOutputParser.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/parsers/LogOutputParser.java
@@ -19,6 +19,8 @@ public final class LogOutputParser {
     // Utility classes shouldn't have default constructors
     private LogOutputParser() { }
 
+    // DigesterUtils will return a secured Digester unless there's a UNSAFE property in LogOutputParser set to "true"
+    @SuppressWarnings("lgtm[jenkins/unsafe-classes]")
     public static List<ChangeSet> parseFile(
             FilePath path, String repoName, String server) throws IOException, ParseException {
         List<ChangeSet> csetList = new ArrayList<>();


### PR DESCRIPTION
This PR dismisses some security alerts about using potentially unsafe classes:
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/9
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/10
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/11
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/12

They're warning about the usage of `org.apache.commons.digester3.Digester`, which has uses `org.xml.sax.XMLReader` underneath and it's therefore vulnerable to XML eXternal Entity injection (XXE). 

The plugin builds the `Digester` via `DigesterUtils`, which already applies the protections in https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#xmlreader .

We can safely dismiss this alerts, as we're already protecting our XML readers.

### Testing done

Not needed. This PR only adds `@SuppressWarnings` annotations.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue