### PR TITLE
Dismiss missing permission check alerts in form validation methods

### DIFF
--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
@@ -680,6 +680,7 @@ public class PlasticSCM extends SCM {
             return "Plastic SCM";
         }
 
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         @RequirePOST
         public static FormValidation doCheckSelector(@QueryParameter String value) {
             return FormChecker.doCheckSelector(value);
@@ -767,6 +768,7 @@ public class PlasticSCM extends SCM {
         @Extension
         public static class DescriptorImpl extends Descriptor<WorkspaceInfo> {
 
+            @SuppressWarnings("lgtm[jenkins/no-permission-check]")
             @RequirePOST
             public static FormValidation doCheckSelector(@QueryParameter String value) {
                 return FormChecker.doCheckSelector(value);

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
@@ -175,16 +175,19 @@ public class PlasticSCMStep extends SCMStep {
             return "Plastic SCM";
         }
 
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         @RequirePOST
         public FormValidation doCheckBranch(@QueryParameter String value) {
             return FormChecker.doCheckBranch(value);
         }
 
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         @RequirePOST
         public FormValidation doCheckRepository(@QueryParameter String value) {
             return FormChecker.doCheckRepository(value);
         }
 
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         @RequirePOST
         public FormValidation doCheckServer(@QueryParameter String value) {
             return FormChecker.doCheckServer(value);

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScm.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScm.java
@@ -222,6 +222,7 @@ public class MergebotScm extends SCM {
             return FormFiller.doFillCredentialsIdItems(item, credentialsId);
         }
 
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         @RequirePOST
         public static FormValidation doCheckSpeckAttributeName(@QueryParameter String value) {
             return Util.fixEmpty(value) == null

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmStep.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmStep.java
@@ -93,6 +93,7 @@ public class MergebotScmStep extends SCMStep {
             return MergebotScm.UPDATE_TO_SPEC_PARAMETER_NAME;
         }
 
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         @RequirePOST
         public static FormValidation doCheckSpecAttributeName(@QueryParameter String value) {
             return Util.fixEmpty(value) == null

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
@@ -166,6 +166,7 @@ public class CmTool extends ToolInstallation implements NodeSpecific<CmTool>, En
             return "plasticscm-cli";
         }
 
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         @RequirePOST
         @Override
         public FormValidation doCheckHome(@QueryParameter File value) {


### PR DESCRIPTION
This PR dismisses the following security alerts:

* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/1
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/2
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/3
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/4
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/5
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/6
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/7
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/8

Those were false positives. The method in `CmTool` performs the permissions check inside `FormValidation.validateExecutable()`, and the other methods only check whether the incoming values match the expectd format. They don't access sensitive information.

### Testing done

Not needed. This PR only adds `@SuppressWarnings` annotations.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
