### PR TITLE
Code cleanup after upgrade

### DIFF
--- a/src/main/java/com/codicesoftware/plugins/hudson/ChangeSetWriter.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/ChangeSetWriter.java
@@ -53,7 +53,7 @@ public class ChangeSetWriter {
         writer.println(String.format("\t\t<repname>%s</repname>", escapeForXml(changeSet.getRepoName())));
         writer.println(String.format("\t\t<repserver>%s</repserver>", escapeForXml(changeSet.getRepoServer())));
         writer.println(String.format("\t\t<guid>%s</guid>", escapeForXml(changeSet.getGuid())));
-        if (changeSet.getItems().size() > 0) {
+        if (!changeSet.getItems().isEmpty()) {
             writer.println("\t\t<items>");
             for (ChangeSet.Item item : changeSet.getItems()) {
                 writer.println(String.format("\t\t\t<item revId=\"%s\" parentRevId=\"%s\" status=\"%s\">%s</item>",

--- a/src/main/java/com/codicesoftware/plugins/hudson/ClientConfigurationArguments.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/ClientConfigurationArguments.java
@@ -47,17 +47,17 @@ public class ClientConfigurationArguments {
 
     @Nonnull
     String getWorkingModeParam() {
-        return "--workingmode=" + workingMode.getPlasticWorkingMode();
+        return workingMode == null ? "" : "--workingmode=" + workingMode.getPlasticWorkingMode();
     }
 
     @Nonnull
     String getUserParam() {
-        return "--username=" + credentials.getUsername();
+        return credentials == null ? "" : "--username=" + credentials.getUsername();
     }
 
     @Nonnull
     String getPasswordParam() {
-        return "--password=" + Secret.toString(credentials.getPassword());
+        return credentials == null ? "" : "--password=" + Secret.toString(credentials.getPassword());
     }
 
     boolean hasWorkingModeManualValues() {

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
@@ -181,6 +181,7 @@ public class PlasticSCM extends SCM {
     }
 
     @Exported
+    @SuppressWarnings("unused")
     public List<WorkspaceInfo> getAdditionalWorkspaces() {
         return additionalWorkspaces;
     }
@@ -196,6 +197,7 @@ public class PlasticSCM extends SCM {
     }
 
     @Exported
+    @SuppressWarnings("unused")
     public boolean isPollOnController() {
         return pollOnController;
     }
@@ -651,6 +653,7 @@ public class PlasticSCM extends SCM {
 
     // endregion
 
+    @SuppressWarnings("unused")
     @Extension
     public static class DescriptorImpl extends SCMDescriptor<PlasticSCM> {
         public DescriptorImpl() {
@@ -750,6 +753,7 @@ public class PlasticSCM extends SCM {
             return directory;
         }
 
+        @SuppressWarnings("unused")
         @Extension
         public static class DescriptorImpl extends Descriptor<WorkspaceInfo> {
 

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
@@ -106,12 +106,10 @@ public class PlasticSCM extends SCM {
 
     private final String selector;
 
-    private CleanupMethod cleanup;
+    private final CleanupMethod cleanup;
     private final WorkingMode workingMode;
     @CheckForNull
     private final String credentialsId;
-    @Deprecated
-    private transient boolean useUpdate;
 
     private final List<WorkspaceInfo> additionalWorkspaces;
     private final WorkspaceInfo firstWorkspace;
@@ -127,7 +125,7 @@ public class PlasticSCM extends SCM {
             String selector,
             CleanupMethod cleanup,
             WorkingMode workingMode,
-            String credentialsId,
+            @CheckForNull String credentialsId,
             boolean useMultipleWorkspaces,
             List<WorkspaceInfo> additionalWorkspaces,
             boolean pollOnController,
@@ -158,8 +156,7 @@ public class PlasticSCM extends SCM {
 
     @Exported
     public CleanupMethod getCleanup() {
-        // Field might be null if deserialized from older class version.
-        return (cleanup != null) ? cleanup : CleanupMethod.convertUseUpdate(useUpdate);
+        return cleanup;
     }
 
     @Exported
@@ -168,6 +165,7 @@ public class PlasticSCM extends SCM {
         return (workingMode != null) ? workingMode : WorkingMode.NONE;
     }
 
+    @CheckForNull
     @Exported
     public String getCredentialsId() {
         return credentialsId;
@@ -245,7 +243,6 @@ public class PlasticSCM extends SCM {
             @CheckForNull final SCMRevisionState baseline) throws IOException, InterruptedException {
 
         Node node = BuildNode.getFromWorkspacePath(workspace);
-        adjustFieldsIfUsingOldConfigFormat();
 
         List<ChangeSet> changeLogItems = new ArrayList<>();
 
@@ -401,16 +398,6 @@ public class PlasticSCM extends SCM {
     // endregion
 
     // region Private methods
-
-    /**
-     * Backward compatibility for jobs using old configuration format.
-     */
-    private void adjustFieldsIfUsingOldConfigFormat() {
-        if (cleanup == null) {
-            LOGGER.warning("Missing 'cleanup' field. Update job configuration.");
-            cleanup = CleanupMethod.convertUseUpdate(useUpdate);
-        }
-    }
 
     private static FilePath resolveWorkspacePath(
             FilePath jenkinsWorkspacePath,
@@ -718,8 +705,6 @@ public class PlasticSCM extends SCM {
         private final String selector;
 
         private final CleanupMethod cleanup;
-        @Deprecated
-        private transient boolean useUpdate;
 
         private final String directory;
 
@@ -742,8 +727,7 @@ public class PlasticSCM extends SCM {
 
         @Exported
         public CleanupMethod getCleanup() {
-            // Field might be null if deserialized from older class version.
-            return (cleanup != null) ? cleanup : CleanupMethod.convertUseUpdate(useUpdate);
+            return cleanup;
         }
 
         @Exported

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
@@ -26,7 +26,6 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
@@ -298,21 +297,6 @@ public class PlasticSCM extends SCM {
         }
     }
 
-    /**
-     * Jenkins older than 2.60
-     * {@inheritDoc}
-     *
-     */
-    @Override
-    public void buildEnvVars(@Nonnull AbstractBuild<?, ?> build, @Nonnull Map<String, String> env) {
-        super.buildEnvVars(build, env);
-        buildEnvironment(build, env);
-    }
-
-    /**
-     * Jenkins 2.60 and newer
-     * {@inheritDoc}
-     */
     @Override
     public void buildEnvironment(@Nonnull Run<?, ?> build, @Nonnull Map<String, String> env) {
         int index = 1;
@@ -514,7 +498,7 @@ public class PlasticSCM extends SCM {
             @Nonnull final ChangeSet toCset) throws IOException, InterruptedException {
 
         if (fromCset == null) {
-            return new ArrayList<ChangeSet>() {{ add(toCset); }};
+            return new ArrayList<>() {{ add(toCset); }};
         }
 
         FilePath xmlOutputPath = OutputTempFile.getPathForXml(workspacePath);
@@ -561,7 +545,7 @@ public class PlasticSCM extends SCM {
         }
 
         if (workspacePath == null) {
-            workspacePath = new FilePath(new FilePath(Jenkins.getInstance().getRootDir()), CONTROLLER_WORKSPACE_FOLDER);
+            workspacePath = new FilePath(new FilePath(Jenkins.get().getRootDir()), CONTROLLER_WORKSPACE_FOLDER);
             workspacePath.mkdirs();
         }
 
@@ -581,7 +565,7 @@ public class PlasticSCM extends SCM {
                 repSpec,
                 lastCompletedBuildTimestamp,
                 Calendar.getInstance());
-            return changesetsFromBuild.size() > 0;
+            return !changesetsFromBuild.isEmpty();
         } catch (Exception e) {
             e.printStackTrace(listener.error(String.format(
                 "%s: Unable to retrieve workspace status.", workspacePath.getRemote())));

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
@@ -27,7 +27,6 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
-import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -47,7 +46,6 @@ import hudson.scm.SCMRevisionState;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
-import jenkins.security.MasterToSlaveCallable;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -777,19 +775,6 @@ public class PlasticSCM extends SCM {
             public String getDisplayName() {
                 return "Plastic SCM Workspace";
             }
-        }
-    }
-
-    private static class GetCurrentNode extends MasterToSlaveCallable<String, InterruptedException> {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public String call() {
-            Node node = Computer.currentComputer().getNode();
-            if (node == null) {
-                return null;
-            }
-            return node.getNodeName();
         }
     }
 }

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
@@ -54,7 +54,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -681,12 +681,12 @@ public class PlasticSCM extends SCM {
         }
 
         @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-        @RequirePOST
+        @POST
         public static FormValidation doCheckSelector(@QueryParameter String value) {
             return FormChecker.doCheckSelector(value);
         }
 
-        @RequirePOST
+        @POST
         public static FormValidation doCheckDirectory(
                 @QueryParameter String value,
                 @QueryParameter boolean useMultipleWorkspaces,
@@ -705,7 +705,7 @@ public class PlasticSCM extends SCM {
             return FormFiller.doFillCredentialsIdItems(item, credentialsId);
         }
 
-        @RequirePOST
+        @POST
         public FormValidation doCheckCredentialsId(
             @AncestorInPath Item item,
             @QueryParameter String value,
@@ -769,12 +769,12 @@ public class PlasticSCM extends SCM {
         public static class DescriptorImpl extends Descriptor<WorkspaceInfo> {
 
             @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-            @RequirePOST
+            @POST
             public static FormValidation doCheckSelector(@QueryParameter String value) {
                 return FormChecker.doCheckSelector(value);
             }
 
-            @RequirePOST
+            @POST
             public static FormValidation doCheckDirectory(@QueryParameter String value, @AncestorInPath Item item) {
                 return FormChecker.doCheckDirectory(value, item);
             }

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCM.java
@@ -701,6 +701,7 @@ public class PlasticSCM extends SCM {
             return SelectorTemplates.DEFAULT;
         }
 
+        @POST
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String credentialsId) {
             return FormFiller.doFillCredentialsIdItems(item, credentialsId);
         }

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
@@ -22,6 +22,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.logging.Logger;
 
+@SuppressWarnings("unused")
 public class PlasticSCMStep extends SCMStep {
 
     private static final Logger LOGGER = Logger.getLogger(PlasticSCMStep.class.getName());
@@ -160,6 +161,7 @@ public class PlasticSCMStep extends SCMStep {
         }
     }
 
+    @SuppressWarnings("unused")
     @Extension
     public static final class DescriptorImpl extends SCMStepDescriptor {
         public static final String defaultBranch = PlasticSCM.DEFAULT_BRANCH;

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
@@ -37,8 +37,6 @@ public class PlasticSCMStep extends SCMStep {
     private WorkingMode workingMode = WorkingMode.NONE;
     private String credentialsId = null;
     private CleanupMethod cleanup = CleanupMethod.STANDARD;
-    @Deprecated
-    private transient boolean useUpdate;
 
     private String directory = "";
 
@@ -125,12 +123,6 @@ public class PlasticSCMStep extends SCMStep {
     @DataBoundSetter
     public void setCleanup(CleanupMethod cleanup) {
         this.cleanup = cleanup;
-    }
-
-    @Deprecated
-    public void setUseUpdate(boolean useUpdate) {
-        LOGGER.warning("Using deprecated 'useUpdate' field. Update job configuration.");
-        this.cleanup = CleanupMethod.convertUseUpdate(useUpdate);
     }
 
     public String getDirectory() {

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
@@ -16,7 +16,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -176,24 +176,24 @@ public class PlasticSCMStep extends SCMStep {
         }
 
         @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-        @RequirePOST
+        @POST
         public FormValidation doCheckBranch(@QueryParameter String value) {
             return FormChecker.doCheckBranch(value);
         }
 
         @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-        @RequirePOST
+        @POST
         public FormValidation doCheckRepository(@QueryParameter String value) {
             return FormChecker.doCheckRepository(value);
         }
 
         @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-        @RequirePOST
+        @POST
         public FormValidation doCheckServer(@QueryParameter String value) {
             return FormChecker.doCheckServer(value);
         }
 
-        @RequirePOST
+        @POST
         public static FormValidation doCheckDirectory(@QueryParameter String value, @AncestorInPath Item item) {
             if (Util.fixEmpty(value) == null) {
                 return FormValidation.ok();
@@ -205,7 +205,7 @@ public class PlasticSCMStep extends SCMStep {
             return FormFiller.doFillCredentialsIdItems(item, credentialsId);
         }
 
-        @RequirePOST
+        @POST
         public FormValidation doCheckCredentialsId(
             @AncestorInPath Item item,
             @QueryParameter String value,

--- a/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/PlasticSCMStep.java
@@ -201,6 +201,7 @@ public class PlasticSCMStep extends SCMStep {
             return FormChecker.doCheckDirectory(value, item);
         }
 
+        @POST
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String credentialsId) {
             return FormFiller.doFillCredentialsIdItems(item, credentialsId);
         }

--- a/src/main/java/com/codicesoftware/plugins/hudson/WorkspaceManager.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/WorkspaceManager.java
@@ -224,7 +224,7 @@ public class WorkspaceManager {
         return fixedNestedPath.startsWith(fixedBasePath);
     }
 
-    private interface WorkspacePathMatcher {
+    protected interface WorkspacePathMatcher {
         boolean matches(String testPath);
     }
 }

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/DiffCommand.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/DiffCommand.java
@@ -8,7 +8,6 @@ import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -45,11 +44,11 @@ public class DiffCommand implements ParseableCommand<List<ChangeSet.Item>> {
 
     @Override
     @Nonnull
-    public List<ChangeSet.Item> parse(@Nonnull final Reader r) throws ParseException, IOException {
+    public List<ChangeSet.Item> parse(@Nonnull final Reader r) throws IOException {
         ArrayList<ChangeSet.Item> result = new ArrayList<>();
 
         BufferedReader reader = new BufferedReader(r);
-        String line = null;
+        String line;
         while ((line = reader.readLine()) != null) {
             Matcher matcher = linePattern.matcher(line);
             if (!matcher.matches()) {

--- a/src/main/java/com/codicesoftware/plugins/hudson/commands/GetSelectorSpecCommand.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/commands/GetSelectorSpecCommand.java
@@ -28,14 +28,11 @@ public class GetSelectorSpecCommand implements ParseableCommand<WorkspaceInfo>, 
     }
 
     public WorkspaceInfo parse(Reader r) throws IOException, ParseException {
-        BufferedReader reader = new BufferedReader(r);
-        try {
+        try (BufferedReader reader = new BufferedReader(r)) {
             String line = reader.readLine();
             return WorkspaceInfoParser.parse(line);
         } catch (Exception e) {
             throw new ParseException("Parse error: " + e.getMessage(), 0);
-        } finally {
-            reader.close();
         }
     }
 }

--- a/src/main/java/com/codicesoftware/plugins/hudson/model/ChangeSet.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/model/ChangeSet.java
@@ -26,7 +26,7 @@ public class ChangeSet extends ChangeLogSet.Entry implements Serializable {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = Logger.getLogger(ChangeSet.class.getName());
 
-    private ObjectSpecType type = ObjectSpecType.Changeset;
+    private ObjectSpecType type;
     private String version;
     private String repoName;
     private String repoServer;
@@ -37,7 +37,7 @@ public class ChangeSet extends ChangeLogSet.Entry implements Serializable {
     private String dateTimeStr;
     private String comment;
     private String guid;
-    private ArrayList<Item> items;
+    private final ArrayList<Item> items;
     private String workspaceDir;
 
     @SuppressWarnings("unused")
@@ -104,18 +104,13 @@ public class ChangeSet extends ChangeLogSet.Entry implements Serializable {
     }
 
     @Override
-    public ChangeLogSet getParent() {
-        return super.getParent();
-    }
-
-    @Override
     protected void setParent(ChangeLogSet parent) {
         super.setParent(parent);
     }
 
     @Override
     public User getAuthor() {
-        return User.get(user);
+        return User.getOrCreateByIdOrFullName(user);
     }
 
     @Override

--- a/src/main/java/com/codicesoftware/plugins/hudson/model/ChangeSet.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/model/ChangeSet.java
@@ -76,7 +76,7 @@ public class ChangeSet extends ChangeLogSet.Entry implements Serializable {
         this.version = o.version;
         this.repoName = o.repoName;
         this.repoServer = o.repoServer;
-        this.dateTime = (dateTime != null) ? OffsetDateTime.from(dateTime) : null;
+        this.dateTime = (o.dateTime != null) ? OffsetDateTime.from(o.dateTime) : null;
         this.dateTimeStr = o.dateTimeStr;
         this.comment = o.comment;
         this.branch = o.branch;

--- a/src/main/java/com/codicesoftware/plugins/hudson/model/ChangeSetList.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/model/ChangeSetList.java
@@ -6,6 +6,7 @@ import hudson.scm.RepositoryBrowser;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -38,6 +39,7 @@ public class ChangeSetList extends ChangeLogSet<ChangeSet> {
         return changesets.isEmpty();
     }
 
+    @Nonnull
     @Override
     public Iterator<ChangeSet> iterator() {
         return changesets.iterator();

--- a/src/main/java/com/codicesoftware/plugins/hudson/model/CleanupMethod.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/model/CleanupMethod.java
@@ -28,8 +28,4 @@ public enum CleanupMethod {
     public boolean removesIgnored() {
         return (this == FULL);
     }
-
-    public static CleanupMethod convertUseUpdate(boolean useUpdate) {
-        return useUpdate ? CleanupMethod.MINIMAL : CleanupMethod.DELETE;
-    }
 }

--- a/src/main/java/com/codicesoftware/plugins/hudson/model/Workspace.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/model/Workspace.java
@@ -14,11 +14,11 @@ import java.io.Serializable;
 public class Workspace implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String name;
+    private final String name;
     @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-    private transient FilePath path;
-    private String pathStr;
-    private String guid;
+    private FilePath path;
+    private final String pathStr;
+    private final String guid;
 
     public Workspace(String name, String path, String guid) {
         this(name, path, guid, null);

--- a/src/main/java/com/codicesoftware/plugins/hudson/util/BuildVariableResolver.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/util/BuildVariableResolver.java
@@ -31,25 +31,17 @@ public class BuildVariableResolver implements VariableResolver<String> {
 
     private static final Logger LOGGER = Logger.getLogger(BuildVariableResolver.class.getName());
     private final Computer computer;
-    private Map<String, LazyResolver> lazyResolvers = new HashMap<>();
-    private List<VariableResolver<String>> otherResolvers = new ArrayList<>();
+    private final Map<String, LazyResolver> lazyResolvers = new HashMap<>();
+    private final List<VariableResolver<String>> otherResolvers = new ArrayList<>();
 
     public BuildVariableResolver(final Job<?, ?> job) {
         computer = null;
-        lazyResolvers.put("JOB_NAME", new LazyResolver() {
-            public String getValue() {
-                return job.getName();
-            }
-        });
+        lazyResolvers.put("JOB_NAME", job::getName);
     }
 
     public BuildVariableResolver(final Job<?, ?> project, final Computer computer, final FilePath workspace) {
         this.computer = computer;
-        lazyResolvers.put("JOB_NAME", new LazyResolver() {
-            public String getValue() {
-                return project.getName();
-            }
-        });
+        lazyResolvers.put("JOB_NAME", project::getName);
         lazyResolvers.put("NODE_NAME", new LazyComputerResolver() {
             public String getValue(Computer computer) {
                 if (computer == null || Util.fixEmpty(computer.getName()) == null) {
@@ -67,7 +59,7 @@ public class BuildVariableResolver implements VariableResolver<String> {
             }
         });
         lazyResolvers.put("EXECUTOR_NUMBER", new LazyComputerResolver() {
-            public String getValue(Computer computer) throws IOException, InterruptedException {
+            public String getValue(Computer computer) {
                 return ExecutorVariableHelper.getExecutorID(workspace);
             }
         });
@@ -98,8 +90,6 @@ public class BuildVariableResolver implements VariableResolver<String> {
 
     /**
      * Class to handle cases when a Launcher was not created from a computer.
-     *
-     * @see hudson.Launcher#getComputer()
      */
     private abstract class LazyComputerResolver implements LazyResolver {
         protected abstract String getValue(Computer computer) throws IOException, InterruptedException;

--- a/src/main/java/com/codicesoftware/plugins/hudson/util/FormChecker.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/util/FormChecker.java
@@ -37,7 +37,7 @@ public class FormChecker {
         Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
     private static final Pattern NO_AT_CHAR_REGEX = Pattern.compile("^[^@]+$");
     private static final Pattern SERVER_REGEX = Pattern.compile("^.+:[0-9]+$");
-    private static final Pattern DIRECTORY_REGEX = Pattern.compile("^[A-Za-z0-9\\-\\_]+$");
+    private static final Pattern DIRECTORY_REGEX = Pattern.compile("^[A-Za-z0-9\\-_]+$");
 
     private FormChecker() { }
 
@@ -100,7 +100,7 @@ public class FormChecker {
             String server,
             WorkingMode workingMode) throws IOException, InterruptedException {
         if (item == null) {
-            if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return FormValidation.ok();
             }
         } else {
@@ -116,12 +116,12 @@ public class FormChecker {
             return FormValidation.error(workingMode.getLabel() + " requires credentials");
         }
         StandardUsernamePasswordCredentials credentials = CredentialsMatchers.firstOrNull(
-            CredentialsProvider.lookupCredentials(
+            CredentialsProvider.lookupCredentialsInItem(
                 StandardUsernamePasswordCredentials.class,
                 item,
                 item instanceof Queue.Task
-                    ? Tasks.getAuthenticationOf((Queue.Task) item)
-                    : ACL.SYSTEM,
+                    ? Tasks.getAuthenticationOf2((Queue.Task) item)
+                    : ACL.SYSTEM2,
                 URIRequirementBuilder.create().build()),
             CredentialsMatchers.withId(value));
 
@@ -136,10 +136,10 @@ public class FormChecker {
         Launcher launcher = new Launcher.LocalLauncher(listener);
 
         PlasticTool tool = new PlasticTool(
-            CmTool.get(Jenkins.getInstance(), new EnvVars(EnvVars.masterEnvVars), listener),
+            CmTool.get(Jenkins.get(), new EnvVars(EnvVars.masterEnvVars), listener),
             launcher,
             listener,
-            Jenkins.getInstance().getRootPath(),
+            Jenkins.get().getRootPath(),
             clientConfArgs);
 
         try {

--- a/src/main/java/com/codicesoftware/plugins/hudson/util/FormFiller.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/util/FormFiller.java
@@ -19,7 +19,7 @@ public final class FormFiller {
     public static ListBoxModel doFillCredentialsIdItems(Item item, String credentialsId) {
         StandardListBoxModel result = new StandardListBoxModel();
         if (item == null) {
-            if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return result.includeCurrentValue(credentialsId);
             }
         } else {
@@ -32,8 +32,8 @@ public final class FormFiller {
             .includeEmptyValue()
             .includeMatchingAs(
                 item instanceof Queue.Task
-                    ? Tasks.getAuthenticationOf((Queue.Task) item)
-                    : ACL.SYSTEM,
+                    ? Tasks.getAuthenticationOf2((Queue.Task) item)
+                    : ACL.SYSTEM2,
                 item,
                 StandardUsernamePasswordCredentials.class,
                 // No domain requirements

--- a/src/main/java/com/codicesoftware/plugins/hudson/util/MaskedArgumentListBuilder.java
+++ b/src/main/java/com/codicesoftware/plugins/hudson/util/MaskedArgumentListBuilder.java
@@ -16,7 +16,7 @@ public class MaskedArgumentListBuilder extends ArgumentListBuilder {
     @Override
     public ArgumentListBuilder prepend(String... args) {
         if (maskedArgumentIndex != null) {
-            Collection<Integer> newMaskedArgumentIndex = new HashSet<Integer>();
+            Collection<Integer> newMaskedArgumentIndex = new HashSet<>();
 
             for (Integer argIndex : maskedArgumentIndex) {
                 newMaskedArgumentIndex.add(argIndex + args.length);
@@ -48,7 +48,7 @@ public class MaskedArgumentListBuilder extends ArgumentListBuilder {
     @Override
     public void addMasked(String string) {
         if (maskedArgumentIndex == null) {
-            maskedArgumentIndex = new HashSet<Integer>();
+            maskedArgumentIndex = new HashSet<>();
         }
         maskedArgumentIndex.add(toCommandArray().length);
         add(string);

--- a/src/main/java/com/codicesoftware/plugins/jenkins/BuildNode.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/BuildNode.java
@@ -14,7 +14,7 @@ public class BuildNode {
 
     @Nonnull
     public static Node getFromWorkspacePath(@Nonnull final FilePath workspacePath) {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
 
         if (!workspacePath.isRemote()) {
             return jenkins;

--- a/src/main/java/com/codicesoftware/plugins/jenkins/CredentialsFinder.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/CredentialsFinder.java
@@ -27,10 +27,10 @@ public class CredentialsFinder {
         }
 
         return CredentialsMatchers.firstOrNull(
-            CredentialsProvider.lookupCredentials(
+            CredentialsProvider.lookupCredentialsInItem(
                 StandardUsernamePasswordCredentials.class,
                 item,
-                item instanceof Queue.Task ? ((Queue.Task) item).getDefaultAuthentication() : ACL.SYSTEM,
+                item instanceof Queue.Task ? ((Queue.Task) item).getDefaultAuthentication2() : ACL.SYSTEM2,
                 URIRequirementBuilder.create().build()),
             CredentialsMatchers.withId(credentialsId));
     }

--- a/src/main/java/com/codicesoftware/plugins/jenkins/PlasticSCMFile.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/PlasticSCMFile.java
@@ -137,7 +137,7 @@ public class PlasticSCMFile extends SCMFile {
     @Nonnull
     @Override
     public Iterable<SCMFile> children() {
-        return new ArrayList<SCMFile>();
+        return new ArrayList<>();
     }
 
     @Override
@@ -183,7 +183,7 @@ public class PlasticSCMFile extends SCMFile {
                 environment);
 
             PlasticTool tool = new PlasticTool(
-                CmTool.get(Jenkins.getInstance(), environment, listener),
+                CmTool.get(Jenkins.get(), environment, listener),
                 launcher,
                 listener,
                 null,

--- a/src/main/java/com/codicesoftware/plugins/jenkins/PlasticSCMFileSystem.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/PlasticSCMFileSystem.java
@@ -16,7 +16,6 @@ import jenkins.scm.impl.SingleSCMSource;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -54,7 +53,7 @@ public class PlasticSCMFileSystem extends SCMFileSystem {
     }
 
     @Override
-    public long lastModified() throws IOException, InterruptedException {
+    public long lastModified() {
         return 0;
     }
 
@@ -75,10 +74,6 @@ public class PlasticSCMFileSystem extends SCMFileSystem {
         public SCMFileSystem build(@Nonnull Item owner,
                 @Nonnull SCM scm,
                 @CheckForNull SCMRevision rev) {
-            if (scm == null) {
-                return null;
-            }
-
             if (!isPlasticSCM(scm)) {
                 return null;
             }

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScm.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScm.java
@@ -38,7 +38,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -223,7 +223,7 @@ public class MergebotScm extends SCM {
         }
 
         @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-        @RequirePOST
+        @POST
         public static FormValidation doCheckSpeckAttributeName(@QueryParameter String value) {
             return Util.fixEmpty(value) == null
                     ? FormValidation.error("The attribute name cannot be empty")

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScm.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScm.java
@@ -17,7 +17,6 @@ import com.codicesoftware.plugins.jenkins.ChangesetDetails;
 import com.codicesoftware.plugins.jenkins.CredentialsFinder;
 import com.codicesoftware.plugins.jenkins.UpdateToSpec;
 import com.codicesoftware.plugins.jenkins.tools.CmTool;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
@@ -92,7 +91,7 @@ public class MergebotScm extends SCM {
         return specAttributeName;
     }
 
-    @NonNull
+    @Nonnull
     @Override
     public String getKey() {
         return String.format(
@@ -173,7 +172,7 @@ public class MergebotScm extends SCM {
             @Nonnull final Run<?, ?> run,
             @Nullable final FilePath wkPath,
             @Nullable final Launcher launcher,
-            @Nonnull final TaskListener listener) throws IOException, InterruptedException {
+            @Nonnull final TaskListener listener) {
         return SCMRevisionState.NONE;
     }
 
@@ -190,7 +189,7 @@ public class MergebotScm extends SCM {
             @Nonnull final File changelogFile,
             @Nonnull final ChangeSet buildObject) throws AbortException {
         try {
-            ChangeSetWriter.write(new ArrayList<ChangeSet>() {{ add(buildObject); }}, changelogFile);
+            ChangeSetWriter.write(new ArrayList<>() {{ add(buildObject); }}, changelogFile);
         } catch (Exception e) {
             throw AbortExceptionBuilder.build(LOGGER, listener, e);
         }
@@ -203,7 +202,7 @@ public class MergebotScm extends SCM {
             load();
         }
 
-        @NonNull
+        @Nonnull
         @Override
         public String getDisplayName() {
             return "Mergebot - Plastic SCM";

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScm.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScm.java
@@ -195,6 +195,7 @@ public class MergebotScm extends SCM {
         }
     }
 
+    @SuppressWarnings("unused")
     @Extension
     public static class DescriptorImpl extends SCMDescriptor<MergebotScm> {
         public DescriptorImpl() {

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScm.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScm.java
@@ -218,6 +218,7 @@ public class MergebotScm extends SCM {
             return MergebotScm.UPDATE_TO_SPEC_PARAMETER_NAME;
         }
 
+        @POST
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String credentialsId) {
             return FormFiller.doFillCredentialsIdItems(item, credentialsId);
         }

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmFile.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmFile.java
@@ -48,18 +48,18 @@ public class MergebotScmFile extends SCMFile {
 
     @Nonnull
     @Override
-    public Iterable<SCMFile> children() throws IOException, InterruptedException {
-        return new ArrayList<SCMFile>();
+    public Iterable<SCMFile> children() {
+        return new ArrayList<>();
     }
 
     @Override
-    public long lastModified() throws IOException, InterruptedException {
+    public long lastModified() {
         return 0;
     }
 
     @Nonnull
     @Override
-    protected Type type() throws IOException, InterruptedException {
+    protected Type type() {
         return isDir ? Type.DIRECTORY : Type.REGULAR_FILE;
     }
 
@@ -82,7 +82,7 @@ public class MergebotScmFile extends SCMFile {
 
         try {
             PlasticTool tool = new PlasticTool(
-                CmTool.get(Jenkins.getInstance(), environment, taskListener),
+                CmTool.get(Jenkins.get(), environment, taskListener),
                 launcher,
                 taskListener,
                 null,

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmFileSystem.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmFileSystem.java
@@ -15,7 +15,6 @@ import jenkins.scm.api.SCMSourceDescriptor;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -41,7 +40,7 @@ public class MergebotScmFileSystem extends SCMFileSystem {
     }
 
     @Override
-    public long lastModified() throws IOException, InterruptedException {
+    public long lastModified() {
         return 0;
     }
 

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmStep.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmStep.java
@@ -85,6 +85,7 @@ public class MergebotScmStep extends SCMStep {
             return "Plastic SCM Mergebot Checkout";
         }
 
+        @POST
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String credentialsId) {
             return FormFiller.doFillCredentialsIdItems(item, credentialsId);
         }

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmStep.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmStep.java
@@ -14,7 +14,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.Nonnull;
 
@@ -94,7 +94,7 @@ public class MergebotScmStep extends SCMStep {
         }
 
         @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-        @RequirePOST
+        @POST
         public static FormValidation doCheckSpecAttributeName(@QueryParameter String value) {
             return Util.fixEmpty(value) == null
                 ? FormValidation.error("The attribute name cannot be empty")

--- a/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmStep.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/mergebot/MergebotScmStep.java
@@ -18,6 +18,7 @@ import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.Nonnull;
 
+@SuppressWarnings("unused")
 public class MergebotScmStep extends SCMStep {
 
     private WorkingMode workingMode = WorkingMode.NONE;
@@ -72,6 +73,7 @@ public class MergebotScmStep extends SCMStep {
     }
 
     @Extension
+    @SuppressWarnings("unused")
     public static final class MergebotScmStepDescriptor extends SCMStep.SCMStepDescriptor {
         @Override
         @Nonnull

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
@@ -91,14 +91,10 @@ public class CmTool extends ToolInstallation implements NodeSpecific<CmTool>, En
         return home;
     }
 
-    private static CmTool[] getInstallations(DescriptorImpl descriptor) {
-        CmTool[] installations;
-        try {
-            installations = descriptor.getInstallations();
-        } catch (NullPointerException e) {
-            installations = new CmTool[0];
-        }
-        return installations;
+    @Nonnull
+    private static CmTool[] getInstallations(@Nonnull DescriptorImpl descriptor) {
+        CmTool[] installations = descriptor.getInstallations();
+        return installations == null ? new CmTool[0] : installations;
     }
 
     public static CmTool get(Node node, EnvVars envVars, TaskListener log) throws IOException, InterruptedException {

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
@@ -134,7 +134,7 @@ public class CmTool extends ToolInstallation implements NodeSpecific<CmTool>, En
 
         CmTool[] installations = getInstallations(descriptor);
 
-        if (installations == null || installations.length == 0) {
+        if (installations.length == 0) {
             createDefaultInstallation(descriptor);
         }
     }

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
@@ -22,7 +22,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.Nonnull;
 import java.io.File;
@@ -167,7 +167,7 @@ public class CmTool extends ToolInstallation implements NodeSpecific<CmTool>, En
         }
 
         @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-        @RequirePOST
+        @POST
         @Override
         public FormValidation doCheckHome(@QueryParameter File value) {
             // FormValidation.validateExecutable checks admin access

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmTool.java
@@ -1,6 +1,5 @@
 package com.codicesoftware.plugins.jenkins.tools;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Util;
@@ -85,14 +84,13 @@ public class CmTool extends ToolInstallation implements NodeSpecific<CmTool>, En
     public String getCmPath() {
         String home = getHome();
 
-        if (Util.fixEmptyAndTrim(home) == null) {
+        if (platform != null && Util.fixEmptyAndTrim(home) == null) {
             return platform.getToolName();
         }
 
         return home;
     }
 
-    @SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION", justification = "Paranoia check")
     private static CmTool[] getInstallations(DescriptorImpl descriptor) {
         CmTool[] installations;
         try {

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
@@ -90,6 +90,7 @@ public class CmToolInstaller extends DownloadFromUrlInstaller {
         return super.performInstallation(installableTool, node, log).child(Platform.of(node).getToolName());
     }
 
+    @SuppressWarnings("unused")
     @Exported
     public boolean isIgnoreSystemTool() {
         return ignoreSystemTool;

--- a/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
+++ b/src/main/java/com/codicesoftware/plugins/jenkins/tools/CmToolInstaller.java
@@ -31,7 +31,7 @@ public class CmToolInstaller extends DownloadFromUrlInstaller {
     @Override
     public Installable getInstallable() throws IOException {
         Installable installable = super.getInstallable();
-        return installable != null ? new PlasticScmInstallable(installable) : installable;
+        return installable != null ? new PlasticScmInstallable(installable) : null;
     }
 
     @Override
@@ -42,7 +42,7 @@ public class CmToolInstaller extends DownloadFromUrlInstaller {
 
     @Override
     public ToolInstallerDescriptor<?> getDescriptor() {
-        return (DescriptorImpl) Jenkins.getInstance().getDescriptorOrDie(CmToolInstaller.class);
+        return (DescriptorImpl) Jenkins.get().getDescriptorOrDie(CmToolInstaller.class);
     }
 
     @Override
@@ -131,7 +131,7 @@ public class CmToolInstaller extends DownloadFromUrlInstaller {
         }
 
         @Override
-        public List<? extends Installable> getInstallables() throws IOException {
+        public List<? extends Installable> getInstallables() {
             Installable installable = new Installable() {
                 {
                     name = "Latest";

--- a/src/test/java/com/codicesoftware/plugins/hudson/PlasticSCMTest.java
+++ b/src/test/java/com/codicesoftware/plugins/hudson/PlasticSCMTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertTrue;
 public class PlasticSCMTest {
 
     @Rule
-    public JenkinsRule rule = new JenkinsRule();
+    public final JenkinsRule rule = new JenkinsRule();
 
     @Test
     public void testProjectConfig() throws Exception {
@@ -65,7 +65,7 @@ public class PlasticSCMTest {
     @Test
     public void testServerConfiguration() throws Exception {
         FreeStyleProject project = rule.createFreeStyleProject();
-        String newLine = System.getProperty("line.separator");
+        String newLine = System.lineSeparator();
         String selector = String.join(
                 newLine,
                 "repository \"myRepo@my.plasticscm.server.com:8087\"",
@@ -81,6 +81,8 @@ public class PlasticSCMTest {
                 null,
                 true,
                 "");
-        assertEquals("--server=my.plasticscm.server.com:8087", scm.buildClientConfigurationArguments(project, selector).getServerParam());
+        assertEquals(
+                "--server=my.plasticscm.server.com:8087",
+                scm.buildClientConfigurationArguments(project, selector).getServerParam());
     }
 }

--- a/src/test/java/com/codicesoftware/plugins/hudson/model/ChangeSetListTest.java
+++ b/src/test/java/com/codicesoftware/plugins/hudson/model/ChangeSetListTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertTrue;
 
 public class ChangeSetListTest {
 
-    ChangeSetList underTest = new ChangeSetList(null, null, new ArrayList<>());
+    private final ChangeSetList underTest = new ChangeSetList(null, null, new ArrayList<>());
 
     @Test
     public void testGetKind() {

--- a/src/test/java/com/codicesoftware/plugins/hudson/util/SelectorParametersResolverTest.java
+++ b/src/test/java/com/codicesoftware/plugins/hudson/util/SelectorParametersResolverTest.java
@@ -21,10 +21,14 @@ public class SelectorParametersResolverTest {
 
         EnvVars environment = new EnvVars();
 
-        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample $PARAM text", parameters, environment));
-        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} text", parameters, environment));
-        assertEquals("sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
-        assertEquals("sample true text", SelectorParametersResolver.resolve("sample $BOOL text", parameters, environment));
+        assertEquals(
+            "sample VALUE text", SelectorParametersResolver.resolve("sample $PARAM text", parameters, environment));
+        assertEquals(
+            "sample VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} text", parameters, environment));
+        assertEquals(
+            "sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
+        assertEquals(
+            "sample true text", SelectorParametersResolver.resolve("sample $BOOL text", parameters, environment));
     }
 
     @Test
@@ -32,10 +36,14 @@ public class SelectorParametersResolverTest {
         List<ParameterValue> parameters = new LinkedList<>();
         EnvVars environment = new EnvVars("PARAM", "VALUE", "BOOL", "true");
 
-        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample $PARAM text", parameters, environment));
-        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} text", parameters, environment));
-        assertEquals("sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
-        assertEquals("sample true text", SelectorParametersResolver.resolve("sample $BOOL text", parameters, environment));
+        assertEquals(
+            "sample VALUE text", SelectorParametersResolver.resolve("sample $PARAM text", parameters, environment));
+        assertEquals(
+            "sample VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} text", parameters, environment));
+        assertEquals(
+            "sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
+        assertEquals(
+            "sample true text", SelectorParametersResolver.resolve("sample $BOOL text", parameters, environment));
     }
 
     @Test
@@ -45,10 +53,14 @@ public class SelectorParametersResolverTest {
 
         EnvVars environment = new EnvVars("PARAM", "VALUE");
 
-        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample $PARAM text", parameters, environment));
-        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} text", parameters, environment));
-        assertEquals("sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
-        assertEquals("sample true text", SelectorParametersResolver.resolve("sample $BOOL text", parameters, environment));
+        assertEquals(
+            "sample VALUE text", SelectorParametersResolver.resolve("sample $PARAM text", parameters, environment));
+        assertEquals(
+            "sample VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} text", parameters, environment));
+        assertEquals(
+            "sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
+        assertEquals(
+            "sample true text", SelectorParametersResolver.resolve("sample $BOOL text", parameters, environment));
     }
 
     @Test
@@ -59,9 +71,12 @@ public class SelectorParametersResolverTest {
 
         EnvVars environment = new EnvVars();
 
-        assertEquals("sample VALUE text", SelectorParametersResolver.resolve("sample %PARAM% text", parameters, environment));
-        assertEquals("sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
-        assertEquals("sample true text", SelectorParametersResolver.resolve("sample %BOOL% text", parameters, environment));
+        assertEquals(
+            "sample VALUE text", SelectorParametersResolver.resolve("sample %PARAM% text", parameters, environment));
+        assertEquals(
+            "sample PARAM text", SelectorParametersResolver.resolve("sample PARAM text", parameters, environment));
+        assertEquals(
+            "sample true text", SelectorParametersResolver.resolve("sample %BOOL% text", parameters, environment));
     }
 
     @Test
@@ -72,8 +87,14 @@ public class SelectorParametersResolverTest {
 
         EnvVars environment = new EnvVars();
 
-        assertEquals("sample VALUE VALUE text", SelectorParametersResolver.resolve("sample %PARAM% $PARAM text", parameters, environment));
-        assertEquals("sample VALUE VALUE text", SelectorParametersResolver.resolve("sample ${PARAM} %PARAM% text", parameters, environment));
-        assertEquals("sample true true text", SelectorParametersResolver.resolve("sample $BOOL %BOOL% text", parameters, environment));
+        assertEquals(
+            "sample VALUE VALUE text",
+                SelectorParametersResolver.resolve("sample %PARAM% $PARAM text", parameters, environment));
+        assertEquals(
+            "sample VALUE VALUE text",
+                SelectorParametersResolver.resolve("sample ${PARAM} %PARAM% text", parameters, environment));
+        assertEquals(
+            "sample true true text",
+                SelectorParametersResolver.resolve("sample $BOOL %BOOL% text", parameters, environment));
     }
 }


### PR DESCRIPTION
After upgrading the minimum Jenkins version to `2.440.3` and the Java version to 17, there are a few warnings popping up. We're also using deprecated code and outdated java statements that would benefit from an upgrade.

There are also four security alerts fixed in this PR:
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/13
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/14
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/15
* https://github.com/jenkinsci/plasticscm-plugin/security/code-scanning/16

### Testing done

I tested the plugin manually in the official docker container. The `CmTool`, its custom installer and the two VCS implementations (mergebot and regular) worked as expected, for pipelines and freestyle projects.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
